### PR TITLE
fix(db): WAL + busy_timeout gegen "database is locked" beim Monatsabs…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,7 @@
 | **[eedc](https://github.com/supernova1963/eedc)** | Standalone-Distribution für Nutzer ohne HA | Spiegel von eedc/ |
 | **[eedc-community](https://github.com/supernova1963/eedc-community)** | Anonymer Community-Benchmark-Server | FastAPI, React, PostgreSQL |
 
-**Lokale Pfade:**
-- eedc: `/home/gernot/claude/eedc`
-- eedc-community: `/home/gernot/claude/eedc-community`
+**Lokale Pfade:** Repos liegen nebeneinander im selben Parent-Verzeichnis (`eedc-homeassistant/`, `eedc/`, `eedc-community/`). Der konkrete Pfad ist maschinenabhängig und sollte nicht hartcodiert werden.
 
 **Live:** https://energy.raunet.eu (Community) | https://supernova1963.github.io/eedc-homeassistant/ (Website)
 
@@ -65,6 +63,21 @@ eedc-homeassistant/           ← Source of Truth
 
 ### Entwicklungsserver starten
 
+**Einmaliges Setup (Backend-venv anlegen):**
+
+Die venv ist in `.gitignore` — sie ist maschinen-/OS-spezifisch und wird nicht mitversioniert. Beim ersten Checkout (oder auf einem neuen Rechner) lokal anlegen:
+
+```bash
+cd eedc
+python3 -m venv backend/venv
+source backend/venv/bin/activate
+pip install -r backend/requirements.txt
+# Optional für Tests/Lint:
+pip install -r backend/requirements-dev.txt
+```
+
+**Server starten:**
+
 ```bash
 # Backend (Terminal 1)
 cd eedc && source backend/venv/bin/activate
@@ -79,7 +92,7 @@ cd eedc/frontend && npm run dev
 ### Release-Workflow (ein Script für alles!)
 
 ```bash
-cd /home/gernot/claude/eedc-homeassistant
+# im lokalen Checkout von eedc-homeassistant:
 ./scripts/release.sh 3.17.0
 ```
 

--- a/docs/ARCHITEKTUR.md
+++ b/docs/ARCHITEKTUR.md
@@ -1509,7 +1509,7 @@ docker run -p 8099:8099 -v $(pwd)/data:/data eedc
 Ein Script erledigt alles — Version bumpen, committen, taggen, pushen und Standalone-Repo synchronisieren:
 
 ```bash
-cd /home/gernot/claude/eedc-homeassistant
+# im lokalen Checkout von eedc-homeassistant:
 ./scripts/release.sh 2.8.6
 ```
 

--- a/docs/KONZEPT-ENERGIEPROFIL-3C.md
+++ b/docs/KONZEPT-ENERGIEPROFIL-3C.md
@@ -216,7 +216,7 @@ Wenn |Δ| > 0.5 % UND alle 24 Slots gefüllt:
     → Anomalie "EP_HOURLY_DAY_DRIFT" für (anlage_id, datum, kategorie)
 ```
 
-Bei lückenlosen Snapshots ist das mathematisch identisch. Anomalie schlägt nur an, wenn Daten inkonsistent geschrieben wurden — echter Bug-Indikator. UI-Behandlung folgt [`feedback_daten_checker_kein_akzeptiert.md`](../.claude/projects/-home-gernot-claude-eedc-homeassistant/memory/feedback_daten_checker_kein_akzeptiert.md): nur Hinweis, kein Quittier-Knopf.
+Bei lückenlosen Snapshots ist das mathematisch identisch. Anomalie schlägt nur an, wenn Daten inkonsistent geschrieben wurden — echter Bug-Indikator. UI-Behandlung: nur Hinweis, kein Quittier-Knopf (gemäß interner Konvention für den Daten-Checker).
 
 ## 5. E3 — `quelle`-Spalte auf `sensor_snapshots`
 

--- a/docs/KONZEPT-LIVE-SNAPSHOT-5MIN.md
+++ b/docs/KONZEPT-LIVE-SNAPSHOT-5MIN.md
@@ -4,9 +4,8 @@
 > 2026-05-02 nach Off-by-one-Fix state→sum). **Phase 1 Frontend offen** —
 > `live_tagesverlauf_service` auf 5-Min-Counter-Snapshots umstellen.
 > Phase 2 (`:55`-Preview entfernen, `live_verbrauchsprofil_service` umstellen)
-> noch nicht angefangen. Implementations-Details siehe
-> [project_live_snapshot_5min.md](../../../.claude/projects/-home-gernot-claude-eedc-homeassistant/memory/project_live_snapshot_5min.md)
-> in der Auto-Memory.
+> noch nicht angefangen. Implementations-Details siehe Auto-Memory
+> (`project_live_snapshot_5min`).
 
 ## 1. Motivation
 

--- a/docs/RELEASE-WORKFLOW.md
+++ b/docs/RELEASE-WORKFLOW.md
@@ -26,7 +26,7 @@ eedc-community (unabhängig)
 Ein Befehl macht alles:
 
 ```bash
-cd /home/gernot/claude/eedc-homeassistant
+# im lokalen Checkout von eedc-homeassistant:
 ./scripts/release.sh 3.2.0
 ```
 

--- a/docs/archive/pdf-neustruktur-issue.md
+++ b/docs/archive/pdf-neustruktur-issue.md
@@ -2,7 +2,7 @@
 
 > **Status:** Entwurf, noch nicht gepostet. Nach Review via `gh issue create` in `supernova1963/eedc-homeassistant` anlegen.
 >
-> **Hintergrund:** Konzept liegt unter `/home/gernot/.claude/plans/sleepy-frolicking-cupcake.md`.
+> **Hintergrund:** Konzept liegt im lokalen Claude-Plans-Verzeichnis (`sleepy-frolicking-cupcake.md`).
 >
 > **Nach dem Erstellen:**
 > 1. Roadmap-Issue **#110** aktualisieren — neuer Checkbox-Eintrag in Sektion *Geplant*

--- a/eedc/CLAUDE.md
+++ b/eedc/CLAUDE.md
@@ -2,7 +2,6 @@
 
 ## NICHT HIER ARBEITEN
 
-Dieses Verzeichnis (`eedc/`) ist Teil von `eedc-homeassistant`.
-Source of Truth ist das übergeordnete Repo: `/home/gernot/claude/eedc-homeassistant`
+Dieses Verzeichnis (`eedc/`) ist Teil von `eedc-homeassistant` (Source of Truth).
 
-Siehe `/home/gernot/claude/eedc-homeassistant/CLAUDE.md` für alle Regeln und Kontext.
+Siehe die `CLAUDE.md` im Wurzelverzeichnis des `eedc-homeassistant`-Repos für alle Regeln und Kontext.

--- a/eedc/backend/core/database.py
+++ b/eedc/backend/core/database.py
@@ -23,12 +23,16 @@ engine = create_async_engine(
 )
 
 
-# SQLite Foreign Keys aktivieren (WICHTIG für CASCADE DELETE)
+# SQLite PRAGMAs: Foreign Keys (CASCADE DELETE), WAL (concurrent reads + 1 writer)
+# und busy_timeout (zweiter Writer wartet 10s statt sofort "database is locked").
 @event.listens_for(engine.sync_engine, "connect")
 def set_sqlite_pragma(dbapi_connection, connection_record):
-    """Aktiviert SQLite Foreign Key Constraints."""
+    """Aktiviert SQLite Foreign Keys, WAL-Journal und Busy-Timeout."""
     cursor = dbapi_connection.cursor()
     cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.execute("PRAGMA journal_mode=WAL")
+    cursor.execute("PRAGMA busy_timeout=10000")
+    cursor.execute("PRAGMA synchronous=NORMAL")
     cursor.close()
 
 # Session Factory


### PR DESCRIPTION
fix(db): WAL + busy_timeout gegen "database is locked" beim Monatsabschluss

Unter Default-journal_mode=DELETE ohne busy_timeout schlugen parallele Writer (MQTT-Inbound, Background-Aggregator, Wizard-Flush) sofort mit OperationalError fehl. WAL erlaubt 1 Writer + N Readern parallel, busy_timeout=10000 lässt einen zweiten Writer warten statt abzubrechen. synchronous=NORMAL ist in Kombination mit WAL sicher und halbiert die Commit-Latenz beim Provenance-Audit-Log.