### PR TITLE
fix(db): HA-Backup-Konsistenz via WAL-Checkpoint pre-Backup-Hook

### DIFF
--- a/eedc/Dockerfile
+++ b/eedc/Dockerfile
@@ -35,6 +35,7 @@ LABEL \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     jq \
+    sqlite3 \
     libpango-1.0-0 \
     libpangoft2-1.0-0 \
     fontconfig \

--- a/eedc/config.yaml
+++ b/eedc/config.yaml
@@ -67,6 +67,10 @@ map:
   - data:rw
   - config:ro  # Lesezugriff auf HA-Config für statistics Datenbank-Abfrage
 
+# Hot-Backup-Konsistenz: WAL ins Hauptfile zurückspielen + truncaten, bevor
+# der Supervisor /data tarballt. App bleibt online, MQTT-Inbound läuft weiter.
+backup_pre: "sqlite3 /data/eedc.db 'PRAGMA wal_checkpoint(TRUNCATE);'"
+
 # Netzwerk (nur intern via Ingress)
 ports:
   8099/tcp: null


### PR DESCRIPTION
## Summary

- Ergänzt einen `backup_pre`-Hook in der HA-Add-on-Konfiguration: vor dem Tarball wird `PRAGMA wal_checkpoint(TRUNCATE)` ausgeführt
- Nimmt `sqlite3` CLI ins Image auf (~2 MB), damit der Hook ohne zusätzlichen API-Endpoint funktioniert

## Hintergrund

Seit WAL-Mode aktiv ist (siehe vorherige Änderung in `database.py`), liegen committete Daten zwischen `eedc.db` und `eedc.db-wal`, bis ein Checkpoint sie ins Hauptfile zurückschreibt. Der HA-Supervisor tarballt `/data` bei Add-on-Backups nicht atomar — werden die drei Files (`.db`, `.db-wal`, `.db-shm`) nacheinander gelesen, kann der Snapshot inkonsistent sein. SQLite-Recovery fängt das meistens auf, aber nicht garantiert.

## Lösung

`backup_pre` in `config.yaml` schiebt vor dem Tarball alle committeten Transaktionen ins Hauptfile zurück und leert die WAL. Der nachfolgende tar-Snapshot sieht eine konsistente `eedc.db` und eine leere `.db-wal`. App bleibt online, MQTT-Inbound läuft weiter (Hot-Backup).

`sqlite3` CLI im Image nebenbei nutzbar für Wartung/Debug via `docker exec`.

## Test plan

- [ ] Add-on neu bauen, `sqlite3 --version` im Container verfügbar
- [ ] HA-Backup auslösen, im Supervisor-Log `backup_pre` Ausführung sichtbar
- [ ] Vor und nach Backup `.db-wal`-Größe prüfen (sollte nach Hook leer/klein sein)
- [ ] Test-Restore eines erzeugten Backups, App startet ohne Recovery-Warnungen
- [ ] MQTT-Inbound während Backup unterbrechungsfrei

🤖 Generated with [Claude Code](https://claude.com/claude-code)