### PR TITLE
feat(speicher): Erfassungs-Schalter `laedt_aus_netz` — Etappe A (#264)

### DIFF
--- a/eedc/backend/api/routes/ha_import.py
+++ b/eedc/backend/api/routes/ha_import.py
@@ -95,11 +95,25 @@ def get_felder_fuer_typ(typ: str, parameter: dict | None = None) -> list[SensorF
             SensorFeld(key="ladung_kwh", label="Ladung", unit="kWh", required=True),
             SensorFeld(key="entladung_kwh", label="Entladung", unit="kWh", required=True),
         ]
+        # Netzladung schon ohne Arbitrage anbieten (z. B. Backup-/Notladung).
+        # Arbitrage impliziert Netzladung — Bedingung ist daher das OR.
+        laedt_aus_netz = bool(
+            parameter
+            and (
+                parameter.get(PARAM_SPEICHER["LAEDT_AUS_NETZ"])
+                or parameter.get(PARAM_SPEICHER["ARBITRAGE_FAEHIG"])
+            )
+        )
+        if laedt_aus_netz:
+            felder.append(SensorFeld(
+                key="speicher_ladung_netz_kwh", label="Netzladung", unit="kWh",
+                optional=True, hint="Ladung aus dem Netz",
+            ))
+        # Ladepreis nur bei echter Arbitrage relevant — sonst läuft Netzladung zum Bezugspreis.
         if parameter and parameter.get(PARAM_SPEICHER["ARBITRAGE_FAEHIG"]):
-            felder.extend([
-                SensorFeld(key="speicher_ladung_netz_kwh", label="Netzladung", unit="kWh", optional=True, hint="Arbitrage"),
-                SensorFeld(key="speicher_ladepreis_cent", label="Ø Ladepreis", unit="ct/kWh", optional=True),
-            ])
+            felder.append(SensorFeld(
+                key="speicher_ladepreis_cent", label="Ø Ladepreis", unit="ct/kWh", optional=True,
+            ))
         return felder
 
     elif typ == "wallbox":

--- a/eedc/backend/core/database.py
+++ b/eedc/backend/core/database.py
@@ -132,6 +132,48 @@ def _migrate_investitionen_parameter_keys_v325(connection) -> None:
             )
 
 
+def _migrate_speicher_laedt_aus_netz_backfill(connection) -> None:
+    """
+    Etappe A (Issue #264): `laedt_aus_netz` als eigener Erfassungs-Schalter.
+
+    `arbitrage_faehig=true` impliziert Netzladung — Bestands-Anlagen mit
+    aktivem Arbitrage-Flag bekommen `laedt_aus_netz=true` gesetzt, damit das
+    Eingabefeld `ladung_netz_kwh` weiter sichtbar bleibt (Bedingung wechselt
+    von `arbitrage_faehig` auf `laedt_aus_netz`).
+
+    Idempotent: läuft beim ersten Mal echt, danach No-Op.
+    """
+    import json
+    from sqlalchemy import text as _text
+
+    rows = connection.execute(_text(
+        "SELECT id, parameter FROM investitionen "
+        "WHERE typ = 'speicher' AND parameter IS NOT NULL"
+    )).fetchall()
+
+    for inv_id, parameter_raw in rows:
+        if not parameter_raw:
+            continue
+        try:
+            params = json.loads(parameter_raw) if isinstance(parameter_raw, str) else dict(parameter_raw)
+        except (TypeError, ValueError):
+            continue
+
+        if not isinstance(params, dict):
+            continue
+
+        if not params.get('arbitrage_faehig'):
+            continue
+        if params.get('laedt_aus_netz') is True:
+            continue  # bereits gesetzt — No-Op
+
+        params['laedt_aus_netz'] = True
+        connection.execute(
+            _text("UPDATE investitionen SET parameter = :p WHERE id = :id"),
+            {'p': json.dumps(params), 'id': inv_id},
+        )
+
+
 def _migrate_verbrauch_daten_keys_v326(connection) -> None:
     """
     v3.25.8 Migration: Drift-Pairs in verbrauch_daten-JSON konsolidieren.
@@ -364,6 +406,10 @@ async def run_migrations(conn):
             # `heizenergie_kwh`/`heizung_kwh`, `ladung_kwh`/`verbrauch_kwh`,
             # `ladung_netz_kwh`/`speicher_ladung_netz_kwh`). Idempotent.
             _migrate_verbrauch_daten_keys_v326(connection)
+
+            # Etappe A (Issue #264): `laedt_aus_netz` als eigener Erfassungs-
+            # Schalter. Backfill: arbitrage_faehig=true ⇒ laedt_aus_netz=true.
+            _migrate_speicher_laedt_aus_netz_backfill(connection)
 
         # Spezialtarife: verwendung-Feld für Strompreise
         if 'strompreise' in inspector.get_table_names():

--- a/eedc/backend/core/field_definitions.py
+++ b/eedc/backend/core/field_definitions.py
@@ -133,12 +133,13 @@ INVESTITION_FELDER: dict = {
             "csv_suffix": "Entladung_kWh",
             "aggregiert_in": "batterie_entladung_sum",
         },
-        # Konditionell — nur wenn arbitrage_faehig=true:
+        # Konditionell — nur wenn laedt_aus_netz=true (arbitrage_faehig impliziert das):
         {
             "feld": "ladung_netz_kwh", "label": "Netzladung", "einheit": "kWh",
-            "bedingung": "arbitrage_faehig",
+            "bedingung": "laedt_aus_netz",
             "csv_suffix": "Netzladung_kWh",
         },
+        # Ladepreis nur bei echter Arbitrage relevant — Backup-/Notladung läuft zum Bezugspreis.
         {
             "feld": "speicher_ladepreis_cent", "label": "Ø Ladepreis", "einheit": "ct/kWh",
             "bedingung": "arbitrage_faehig",
@@ -424,6 +425,9 @@ def get_felder_fuer_investition(
     result = []
     getrennte_strommessung = bool(params.get("getrennte_strommessung"))
     arbitrage_faehig = bool(params.get("arbitrage_faehig"))
+    # Arbitrage impliziert Netzladung — das Flag ist nur ein Erfassungs-Schalter,
+    # die UI für `ladung_netz_kwh` muss auch ohne Arbitrage sichtbar sein können.
+    laedt_aus_netz = bool(params.get("laedt_aus_netz")) or arbitrage_faehig
     v2h_faehig = bool(params.get("v2h_faehig") or params.get("nutzt_v2h"))
     hat_speicher = bool(params.get("hat_speicher"))
 
@@ -446,6 +450,8 @@ def get_felder_fuer_investition(
         elif bedingung == "!getrennte_strommessung" and getrennte_strommessung:
             continue
         elif bedingung == "arbitrage_faehig" and not arbitrage_faehig:
+            continue
+        elif bedingung == "laedt_aus_netz" and not laedt_aus_netz:
             continue
         elif bedingung == "v2h_faehig" and not v2h_faehig:
             continue

--- a/eedc/backend/core/investition_parameter.py
+++ b/eedc/backend/core/investition_parameter.py
@@ -69,6 +69,7 @@ PARAM_SPEICHER: Final[dict[str, str]] = {
     "MAX_LADELEISTUNG_KW": "max_ladeleistung_kw",
     "MAX_ENTLADELEISTUNG_KW": "max_entladeleistung_kw",
     "WIRKUNGSGRAD_PROZENT": "wirkungsgrad_prozent",
+    "LAEDT_AUS_NETZ": "laedt_aus_netz",
     "ARBITRAGE_FAEHIG": "arbitrage_faehig",
     "LADE_DURCHSCHNITTSPREIS_CENT": "lade_durchschnittspreis_cent",
     "ENTLADE_VERMIEDENER_PREIS_CENT": "entlade_vermiedener_preis_cent",
@@ -76,6 +77,7 @@ PARAM_SPEICHER: Final[dict[str, str]] = {
 
 PARAM_SPEICHER_DEFAULTS: Final[dict[str, object]] = {
     "wirkungsgrad_prozent": 95,
+    "laedt_aus_netz": False,
     "arbitrage_faehig": False,
     "lade_durchschnittspreis_cent": 12,
     "entlade_vermiedener_preis_cent": 35,

--- a/eedc/backend/tests/test_speicher_laedt_aus_netz.py
+++ b/eedc/backend/tests/test_speicher_laedt_aus_netz.py
@@ -1,0 +1,190 @@
+"""
+Akzeptanztest Etappe A (Issue #264): `laedt_aus_netz` als Erfassungs-Schalter.
+
+Deckt zwei Schichten ab:
+  1. Field-Resolver (`get_felder_fuer_investition`) — `ladung_netz_kwh`
+     ist sichtbar wenn `laedt_aus_netz=true` ODER `arbitrage_faehig=true`
+     (Implikation), ansonsten nicht.
+  2. Backfill-Migration (`_migrate_speicher_laedt_aus_netz_backfill`) —
+     setzt `laedt_aus_netz=true` für Bestands-Speicher mit
+     `arbitrage_faehig=true`. Idempotent. Speicher ohne Arbitrage und
+     andere Typen bleiben unangetastet.
+
+Self-contained:
+
+    eedc/backend/venv/bin/python eedc/backend/tests/test_speicher_laedt_aus_netz.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+from pathlib import Path
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]  # eedc/
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+from sqlalchemy import create_engine, text  # noqa: E402
+
+from backend.core.database import _migrate_speicher_laedt_aus_netz_backfill  # noqa: E402
+from backend.core.field_definitions import get_felder_fuer_investition  # noqa: E402
+
+
+# ----------------------------------------------------------------------------
+# Field-Resolver
+# ----------------------------------------------------------------------------
+
+def _feldnamen(typ: str, params: dict) -> set[str]:
+    return {f["feld"] for f in get_felder_fuer_investition(typ, params)}
+
+
+def test_resolver_ohne_flag_blendet_netzladung_aus() -> None:
+    felder = _feldnamen("speicher", {"kapazitaet_kwh": 10})
+    assert "ladung_netz_kwh" not in felder, (
+        "ohne laedt_aus_netz/arbitrage_faehig darf das Feld nicht erscheinen"
+    )
+    assert "speicher_ladepreis_cent" not in felder
+    assert "ladung_kwh" in felder
+    assert "entladung_kwh" in felder
+
+
+def test_resolver_laedt_aus_netz_zeigt_nur_netzladung() -> None:
+    felder = _feldnamen("speicher", {"laedt_aus_netz": True})
+    assert "ladung_netz_kwh" in felder
+    # Ladepreis bleibt arbitrage-only
+    assert "speicher_ladepreis_cent" not in felder
+
+
+def test_resolver_arbitrage_impliziert_netzladung() -> None:
+    # arbitrage_faehig=true muss ladung_netz_kwh sichtbar machen, auch wenn
+    # laedt_aus_netz nicht explizit gesetzt ist (Implikation).
+    felder = _feldnamen("speicher", {"arbitrage_faehig": True})
+    assert "ladung_netz_kwh" in felder
+    assert "speicher_ladepreis_cent" in felder
+
+
+def test_resolver_arbitrage_und_laedt_aus_netz() -> None:
+    felder = _feldnamen("speicher", {"arbitrage_faehig": True, "laedt_aus_netz": True})
+    assert "ladung_netz_kwh" in felder
+    assert "speicher_ladepreis_cent" in felder
+
+
+# ----------------------------------------------------------------------------
+# Backfill-Migration
+# ----------------------------------------------------------------------------
+
+def _seed_db():
+    """In-Memory SQLite mit Minimal-`investitionen`-Tabelle und Fixtures."""
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(text(
+            "CREATE TABLE investitionen ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "typ VARCHAR(50) NOT NULL, "
+            "parameter TEXT"
+            ")"
+        ))
+        fixtures = [
+            ("speicher", {"kapazitaet_kwh": 10, "arbitrage_faehig": True}),
+            ("speicher", {"kapazitaet_kwh": 5, "arbitrage_faehig": False}),
+            ("speicher", {"kapazitaet_kwh": 8, "arbitrage_faehig": True, "laedt_aus_netz": True}),
+            ("speicher", None),  # parameter NULL
+            ("e-auto", {"arbitrage_faehig": True}),  # falscher Typ — nicht anfassen
+        ]
+        for typ, params in fixtures:
+            conn.execute(
+                text("INSERT INTO investitionen (typ, parameter) VALUES (:typ, :p)"),
+                {"typ": typ, "p": json.dumps(params) if params is not None else None},
+            )
+    return engine
+
+
+def _load_params(engine, inv_id: int) -> dict | None:
+    with engine.begin() as conn:
+        row = conn.execute(
+            text("SELECT parameter FROM investitionen WHERE id = :id"), {"id": inv_id}
+        ).fetchone()
+    if row is None or row[0] is None:
+        return None
+    return json.loads(row[0])
+
+
+def test_migration_setzt_flag_bei_arbitrage() -> None:
+    engine = _seed_db()
+    with engine.begin() as conn:
+        _migrate_speicher_laedt_aus_netz_backfill(conn)
+
+    assert _load_params(engine, 1) == {
+        "kapazitaet_kwh": 10, "arbitrage_faehig": True, "laedt_aus_netz": True
+    }
+
+
+def test_migration_laesst_nicht_arbitrage_speicher_in_ruhe() -> None:
+    engine = _seed_db()
+    with engine.begin() as conn:
+        _migrate_speicher_laedt_aus_netz_backfill(conn)
+
+    params = _load_params(engine, 2)
+    assert params == {"kapazitaet_kwh": 5, "arbitrage_faehig": False}
+    assert "laedt_aus_netz" not in params
+
+
+def test_migration_ist_idempotent() -> None:
+    engine = _seed_db()
+    with engine.begin() as conn:
+        _migrate_speicher_laedt_aus_netz_backfill(conn)
+        # Zweiter Lauf darf nichts kaputt machen.
+        _migrate_speicher_laedt_aus_netz_backfill(conn)
+
+    # Bereits gesetzter Flag bleibt — keine Verdopplung.
+    assert _load_params(engine, 3) == {
+        "kapazitaet_kwh": 8, "arbitrage_faehig": True, "laedt_aus_netz": True
+    }
+
+
+def test_migration_ignoriert_null_parameter_und_andere_typen() -> None:
+    engine = _seed_db()
+    with engine.begin() as conn:
+        _migrate_speicher_laedt_aus_netz_backfill(conn)
+
+    assert _load_params(engine, 4) is None  # NULL bleibt NULL
+    eauto = _load_params(engine, 5)
+    assert eauto == {"arbitrage_faehig": True}  # e-auto bleibt unverändert
+
+
+# ----------------------------------------------------------------------------
+# Runner
+# ----------------------------------------------------------------------------
+
+ALLE_TESTS = [
+    test_resolver_ohne_flag_blendet_netzladung_aus,
+    test_resolver_laedt_aus_netz_zeigt_nur_netzladung,
+    test_resolver_arbitrage_impliziert_netzladung,
+    test_resolver_arbitrage_und_laedt_aus_netz,
+    test_migration_setzt_flag_bei_arbitrage,
+    test_migration_laesst_nicht_arbitrage_speicher_in_ruhe,
+    test_migration_ist_idempotent,
+    test_migration_ignoriert_null_parameter_und_andere_typen,
+]
+
+
+def main() -> int:
+    fehler = 0
+    for fn in ALLE_TESTS:
+        try:
+            fn()
+            print(f"PASS  {fn.__name__}")
+        except Exception:  # noqa: BLE001
+            fehler += 1
+            print(f"FAIL  {fn.__name__}")
+            traceback.print_exc()
+    if fehler:
+        print(f"\n{fehler} Tests fehlgeschlagen.")
+        return 1
+    print(f"\nAlle {len(ALLE_TESTS)} Tests grün.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eedc/frontend/src/components/forms/InvestitionForm.tsx
+++ b/eedc/frontend/src/components/forms/InvestitionForm.tsx
@@ -154,15 +154,20 @@ export default function InvestitionForm({ investition, anlageId, typ, onSubmit, 
           v2h_entladeleistung_kw: paramStr(params.v2h_entladeleistung_kw),
           ist_dienstlich: (params.ist_dienstlich as boolean) ?? PARAM_E_AUTO_DEFAULTS.ist_dienstlich,
         }
-      case 'speicher':
+      case 'speicher': {
+        const arbitrage = (params.arbitrage_faehig as boolean) ?? PARAM_SPEICHER_DEFAULTS.arbitrage_faehig
+        // Arbitrage impliziert Netzladung — Initial-State spiegelt die Implikation.
+        const laedtAusNetzGespeichert = (params.laedt_aus_netz as boolean) ?? PARAM_SPEICHER_DEFAULTS.laedt_aus_netz
         return {
           kapazitaet_kwh: paramStr(params.kapazitaet_kwh),
           nutzbare_kapazitaet_kwh: paramStr(params.nutzbare_kapazitaet_kwh),
           max_ladeleistung_kw: paramStr(params.max_ladeleistung_kw),
           max_entladeleistung_kw: paramStr(params.max_entladeleistung_kw),
           wirkungsgrad_prozent: paramStr(params.wirkungsgrad_prozent, PARAM_SPEICHER_DEFAULTS.wirkungsgrad_prozent),
-          arbitrage_faehig: (params.arbitrage_faehig as boolean) ?? PARAM_SPEICHER_DEFAULTS.arbitrage_faehig,
+          laedt_aus_netz: arbitrage ? true : laedtAusNetzGespeichert,
+          arbitrage_faehig: arbitrage,
         }
+      }
       case 'waermepumpe':
         return {
           leistung_kw: paramStr(params.leistung_kw),
@@ -236,10 +241,15 @@ export default function InvestitionForm({ investition, anlageId, typ, onSubmit, 
     const { name, value, type, checked } = e.target
     if (name.startsWith('param_')) {
       const paramName = name.replace('param_', '')
-      setParamData(prev => ({
-        ...prev,
-        [paramName]: type === 'checkbox' ? checked : value
-      }))
+      setParamData(prev => {
+        const next = { ...prev, [paramName]: type === 'checkbox' ? checked : value }
+        // Speicher: Arbitrage impliziert Netzladung — Flag mitziehen,
+        // damit das Monatsdaten-Feld `ladung_netz_kwh` sichtbar bleibt.
+        if (paramName === 'arbitrage_faehig' && type === 'checkbox' && checked) {
+          next.laedt_aus_netz = true
+        }
+        return next
+      })
     } else {
       setFormData(prev => ({
         ...prev,
@@ -756,6 +766,24 @@ function TypSpecificFields({ typ, paramData, onChange }: TypSpecificFieldsProps)
               onChange={onChange}
             />
           </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              name="param_laedt_aus_netz"
+              checked={(paramData.laedt_aus_netz as boolean) || (paramData.arbitrage_faehig as boolean)}
+              disabled={paramData.arbitrage_faehig as boolean}
+              onChange={onChange}
+              className="rounded border-gray-300 text-primary-600 focus:ring-primary-500 disabled:opacity-60"
+            />
+            <span className="text-gray-700 dark:text-gray-300">
+              Lädt aus dem Netz (z. B. Backup-/Notladung)
+              {(paramData.arbitrage_faehig as boolean) && (
+                <span className="ml-1 text-xs text-gray-500 dark:text-gray-400">
+                  — automatisch aktiv durch Arbitrage
+                </span>
+              )}
+            </span>
+          </label>
           <label className="flex items-center gap-2 text-sm">
             <input
               type="checkbox"

--- a/eedc/frontend/src/lib/fieldDefinitions.ts
+++ b/eedc/frontend/src/lib/fieldDefinitions.ts
@@ -39,7 +39,7 @@ export const BASIS_FELDER: FeldDefinition[] = [
 const SPEICHER_FELDER: FeldDefinition[] = [
   { feld: 'ladung_kwh',            label: 'Ladung',     einheit: 'kWh'    },
   { feld: 'entladung_kwh',         label: 'Entladung',  einheit: 'kWh'    },
-  { feld: 'ladung_netz_kwh',       label: 'Netzladung', einheit: 'kWh',    bedingung: 'arbitrage_faehig' },
+  { feld: 'ladung_netz_kwh',       label: 'Netzladung', einheit: 'kWh',    bedingung: 'laedt_aus_netz' },
   { feld: 'speicher_ladepreis_cent', label: 'Ø Ladepreis', einheit: 'ct/kWh', bedingung: 'arbitrage_faehig' },
 ]
 
@@ -147,6 +147,8 @@ export function getFelderFuerInvestition(
 
   const getrennt = Boolean(params.getrennte_strommessung)
   const arbitrage = Boolean(params.arbitrage_faehig)
+  // Arbitrage impliziert Netzladung — Flag ist nur Erfassungs-Schalter.
+  const laedtAusNetz = Boolean(params.laedt_aus_netz) || arbitrage
   const v2h = Boolean(params.v2h_faehig || params.nutzt_v2h)
   const hatSpeicher = Boolean(params.hat_speicher)
 
@@ -155,6 +157,7 @@ export function getFelderFuerInvestition(
     if (f.bedingung === 'getrennte_strommessung')  return getrennt
     if (f.bedingung === '!getrennte_strommessung') return !getrennt
     if (f.bedingung === 'arbitrage_faehig')        return arbitrage
+    if (f.bedingung === 'laedt_aus_netz')          return laedtAusNetz
     if (f.bedingung === 'v2h_faehig')              return v2h
     if (f.bedingung === 'hat_speicher')            return hatSpeicher
     return true

--- a/eedc/frontend/src/lib/investitionParameter.ts
+++ b/eedc/frontend/src/lib/investitionParameter.ts
@@ -75,6 +75,7 @@ export const PARAM_SPEICHER = {
   MAX_LADELEISTUNG_KW: 'max_ladeleistung_kw',
   MAX_ENTLADELEISTUNG_KW: 'max_entladeleistung_kw',
   WIRKUNGSGRAD_PROZENT: 'wirkungsgrad_prozent',
+  LAEDT_AUS_NETZ: 'laedt_aus_netz',
   ARBITRAGE_FAEHIG: 'arbitrage_faehig',
   LADE_DURCHSCHNITTSPREIS_CENT: 'lade_durchschnittspreis_cent',
   ENTLADE_VERMIEDENER_PREIS_CENT: 'entlade_vermiedener_preis_cent',
@@ -82,6 +83,7 @@ export const PARAM_SPEICHER = {
 
 export const PARAM_SPEICHER_DEFAULTS = {
   wirkungsgrad_prozent: 95,
+  laedt_aus_netz: false,
   arbitrage_faehig: false,
   lade_durchschnittspreis_cent: 12,
   entlade_vermiedener_preis_cent: 35,
@@ -93,6 +95,7 @@ export interface SpeicherParameter {
   max_ladeleistung_kw?: number
   max_entladeleistung_kw?: number
   wirkungsgrad_prozent?: number
+  laedt_aus_netz?: boolean
   arbitrage_faehig?: boolean
   lade_durchschnittspreis_cent?: number
   entlade_vermiedener_preis_cent?: number


### PR DESCRIPTION
Etappe A der drei-stufigen Umsetzung aus #264.

## Was diese Etappe liefert

Trennt das **Erfassen** einer Netzladung beim Speicher von echter Arbitrage. Bisher war `ladung_netz_kwh` in der Monatsdaten-Maske nur sichtbar, wenn `arbitrage_faehig=true` gesetzt war — Backup-/Notladung ohne Arbitrage konnte deshalb gar nicht eingetragen werden.

**Kein Calc-Eingriff** — die Wirtschaftlichkeitsrechnung bleibt in dieser Etappe unverändert. Diese kommt in Etappe B (Spread-Modell mit Netz-Anteil + gemeinsamer Helper für Aussichten/ROI gegen Drift-Audit D) und Etappe C (dyn. Tarife aus TEP + SoC-Bilanz für η).

## Änderungen

**Backend:**
- `core/investition_parameter.py`: `PARAM_SPEICHER["LAEDT_AUS_NETZ"]` + Default `False`
- `core/field_definitions.py`: `ladung_netz_kwh`-Bedingung auf `laedt_aus_netz`. Resolver wertet `laedt_aus_netz OR arbitrage_faehig` aus (Arbitrage impliziert Netzladung)
- `core/database.py`: idempotente Backfill-Migration `_migrate_speicher_laedt_aus_netz_backfill` — Bestands-Speicher mit `arbitrage_faehig=true` bekommen `laedt_aus_netz=true`
- `api/routes/ha_import.py`: Sensor `speicher_ladung_netz_kwh` jetzt auch ohne Arbitrage sichtbar
- `tests/test_speicher_laedt_aus_netz.py`: 8 neue Test-Cases (Resolver-Sichtbarkeit + Migration-Idempotenz + Edge-Cases)

**Frontend:**
- `lib/investitionParameter.ts`: PARAM_SPEICHER + Default-Spiegel
- `lib/fieldDefinitions.ts`: Bedingungs-Umstellung + Filter-Erweiterung
- `components/forms/InvestitionForm.tsx`: neuer Checkbox „Lädt aus dem Netz" unter Arbitrage. Implikations-Logik im zentralen `handleChange`: bei `arbitrage_faehig=true` wird `laedt_aus_netz` automatisch gesetzt und im UI als disabled mit Hinweis „automatisch aktiv durch Arbitrage" angezeigt

## Tests

```text
backend/venv/bin/python backend/tests/test_speicher_laedt_aus_netz.py
PASS  test_resolver_ohne_flag_blendet_netzladung_aus
PASS  test_resolver_laedt_aus_netz_zeigt_nur_netzladung
PASS  test_resolver_arbitrage_impliziert_netzladung
PASS  test_resolver_arbitrage_und_laedt_aus_netz
PASS  test_migration_setzt_flag_bei_arbitrage
PASS  test_migration_laesst_nicht_arbitrage_speicher_in_ruhe
PASS  test_migration_ist_idempotent
PASS  test_migration_ignoriert_null_parameter_und_andere_typen
Alle 8 Tests grün.
```

Regression auf Speicher-/Import-Tests: 15/15 grün (`test_custom_import_preview_inv_werte`, `test_emob_pool_komponenten`, `test_inv_value_spalten_fallback`).

## Verhalten (UI)

| Setup | Sichtbarkeit `ladung_netz_kwh` | Sichtbarkeit `speicher_ladepreis_cent` |
| --- | --- | --- |
| Default (`laedt_aus_netz=false`, `arbitrage_faehig=false`) | versteckt | versteckt |
| `laedt_aus_netz=true` | **sichtbar** | versteckt |
| `arbitrage_faehig=true` (impliziert `laedt_aus_netz`) | **sichtbar** | **sichtbar** |

## Reihenfolge & Risiken

- API additiv: keine Pflichtfeld-Änderungen, keine Verhaltensänderung für Bestandsdaten ohne Migration.
- Backfill-Migration hebt bestehende Arbitrage-User sauber auf `laedt_aus_netz=true` — kein Datenverlust.
- Folge-PRs (B, C) bauen auf diesem PR auf, sind aber als eigene Feature-Branches ab `upstream/main` geplant.

## Test plan

- [ ] Backend-Tests grün: `python eedc/backend/tests/test_speicher_laedt_aus_netz.py`
- [ ] Backend startet, Backfill-Migration läuft einmal durch (Log-Eintrag), DB-Inspektion: speicher mit `arbitrage_faehig=1` hat danach `laedt_aus_netz=1`
- [ ] Frontend: Investitions-Form Speicher → neuer Toggle „Lädt aus dem Netz" sichtbar
- [ ] Toggle on → Monatsdaten-Maske zeigt `ladung_netz_kwh`-Feld ohne Arbitrage
- [ ] Toggle Arbitrage on → `laedt_aus_netz` automatisch on + disabled (Hinweis-Text)

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)