### PR TITLE
fix(emob): `ist_dienstlich` String-Drift-tolerant lesen

### DIFF
--- a/eedc/backend/api/routes/aktueller_monat.py
+++ b/eedc/backend/api/routes/aktueller_monat.py
@@ -37,6 +37,7 @@ from backend.core.field_definitions import (
     get_wp_strom_kwh,
 )
 from backend.utils.sonstige_positionen import berechne_sonstige_summen
+from backend.core.investition_parameter import ist_dienstlich
 
 logger = logging.getLogger(__name__)
 
@@ -368,7 +369,7 @@ async def _collect_saved_data(
                     (data.get("warmwasser_kwh", 0) or 0)
                 )
             elif inv.typ == "e-auto":
-                if not (inv.parameter or {}).get("ist_dienstlich", False):
+                if not ist_dienstlich(inv):
                     eauto_ladung_total += (
                         data.get("ladung_kwh", 0) or
                         data.get("verbrauch_kwh", 0) or 0
@@ -376,7 +377,7 @@ async def _collect_saved_data(
                     eauto_pv_ladung_total += data.get("ladung_pv_kwh", 0) or 0
                     eauto_km_total += data.get("km_gefahren", 0) or 0
             elif inv.typ == "wallbox":
-                if not (inv.parameter or {}).get("ist_dienstlich", False):
+                if not ist_dienstlich(inv):
                     wb_ladung_total += data.get("ladung_kwh", 0) or 0
                     wb_pv_ladung_total += data.get("ladung_pv_kwh", 0) or 0
             elif inv.typ == "balkonkraftwerk":
@@ -505,8 +506,8 @@ async def _load_vorjahr(anlage_id: int, investitionen: list[Investition], jahr: 
     wp_params_by_id = {i.id: (i.parameter or {}) for i in investitionen if i.typ == "waermepumpe"}
     # E-Auto und Wallbox separat halten — selbe Pool-Doppelzählungs-Falle wie
     # in `_collect_saved_data` (siehe dort). Max-pro-Feld statt Summe.
-    eauto_inv_ids = [i.id for i in investitionen if i.typ == "e-auto" and not (i.parameter or {}).get("ist_dienstlich", False)]
-    wb_inv_ids = [i.id for i in investitionen if i.typ == "wallbox" and not (i.parameter or {}).get("ist_dienstlich", False)]
+    eauto_inv_ids = [i.id for i in investitionen if i.typ == "e-auto" and not ist_dienstlich(i)]
+    wb_inv_ids = [i.id for i in investitionen if i.typ == "wallbox" and not ist_dienstlich(i)]
     all_inv_ids = pv_inv_ids + bat_inv_ids + wp_inv_ids + eauto_inv_ids + wb_inv_ids
 
     if all_inv_ids:
@@ -750,7 +751,7 @@ async def get_aktueller_monat(
         wb_ladung = 0.0
         emob_quelle: Optional[tuple] = None
         for inv in investitionen:
-            if (inv.parameter or {}).get("ist_dienstlich", False):
+            if ist_dienstlich(inv):
                 continue
             # #239 detLAN-Folge: HA-Statistics-Werte aus vor-Anschaffungs-
             # Monaten nicht in den Monatsbericht-Pool aggregieren.
@@ -1036,7 +1037,7 @@ async def get_aktueller_monat(
     emob_ladung_extern = None
     emob_v2h = None
 
-    emob_invs = [i for i in investitionen if i.typ in ("e-auto", "wallbox") and not (i.parameter or {}).get("ist_dienstlich", False)]
+    emob_invs = [i for i in investitionen if i.typ in ("e-auto", "wallbox") and not ist_dienstlich(i)]
     if emob_invs:
         netz_total = 0.0
         extern_total = 0.0
@@ -1162,7 +1163,7 @@ async def get_aktueller_monat(
 
     hat_emobilitaet = any(
         i.typ in ("e-auto", "wallbox")
-        and not (i.parameter or {}).get("ist_dienstlich", False)
+        and not ist_dienstlich(i)
         and i.ist_aktiv_im_monat(jahr, monat)
         for i in investitionen
     )
@@ -1284,7 +1285,7 @@ async def get_aktueller_monat(
                         f"{strom:.1f} kWh × {wp_p:.2f} ct"
                     )
 
-            elif inv.typ in ("e-auto", "wallbox") and not (inv.parameter or {}).get("ist_dienstlich", False):
+            elif inv.typ in ("e-auto", "wallbox") and not ist_dienstlich(inv):
                 km = data.get("km_gefahren")
                 ladung = get_eauto_ladung_kwh(data) or None
                 ladung_netz = data.get("ladung_netz_kwh")

--- a/eedc/backend/api/routes/aussichten.py
+++ b/eedc/backend/api/routes/aussichten.py
@@ -40,6 +40,7 @@ from backend.core.investition_parameter import (
     PARAM_E_AUTO_DEFAULTS,
     PARAM_WAERMEPUMPE,
     PARAM_WAERMEPUMPE_DEFAULTS,
+    ist_dienstlich,
 )
 from backend.utils.sonstige_positionen import berechne_sonstige_netto
 from backend.services.wetter.open_meteo import fetch_open_meteo_forecast
@@ -901,7 +902,7 @@ async def get_finanz_prognose(
     pv_module = [i for i in alle_investitionen if i.typ == "pv-module"]
     speicher = [i for i in alle_investitionen if i.typ == "speicher"]
     e_autos = [i for i in alle_investitionen
-               if i.typ == "e-auto" and not (i.parameter or {}).get("ist_dienstlich", False)]
+               if i.typ == "e-auto" and not ist_dienstlich(i)]
     waermepumpen = [i for i in alle_investitionen if i.typ == "waermepumpe"]
     balkonkraftwerke = [i for i in alle_investitionen if i.typ == "balkonkraftwerk"]
     sonstiges_investitionen = [i for i in alle_investitionen if i.typ == "sonstiges"]
@@ -1226,7 +1227,7 @@ async def get_finanz_prognose(
     # Dienstliche E-Auto/Wallbox-Ladekosten abziehen (Netzbezug + entgangene Einspeisung)
     bisherige_dienstlich_ladekosten = 0.0
     for inv in alle_investitionen:
-        if inv.typ in ("e-auto", "wallbox") and (inv.parameter or {}).get("ist_dienstlich", False):
+        if inv.typ in ("e-auto", "wallbox") and ist_dienstlich(inv):
             for (inv_id, jahr, monat), daten in historische_inv_daten.items():
                 if inv_id == inv.id:
                     netz_kwh = daten.get("ladung_netz_kwh", 0) or 0

--- a/eedc/backend/api/routes/cockpit/komponenten.py
+++ b/eedc/backend/api/routes/cockpit/komponenten.py
@@ -16,6 +16,7 @@ from backend.api.routes.strompreise import lade_tarife_fuer_anlage, resolve_netz
 from backend.utils.sonstige_positionen import berechne_sonstige_summen
 from backend.api.routes.cockpit._shared import MONATSNAMEN
 from backend.services.wp_wirtschaftlichkeit import berechne_wp_ersparnis
+from backend.core.investition_parameter import ist_dienstlich
 from backend.core.wirtschaftlichkeit_defaults import (
     EINSPEISEVERGUETUNG_DEFAULT_CENT,
     NETZBEZUG_DEFAULT_CENT,
@@ -226,7 +227,7 @@ async def get_komponenten_zeitreihe(
             # Dienstwagen rausfiltern (Joachim-Pattern, feedback_dienstwagen_alle_checks.md):
             # ist_dienstlich-Komponenten gehören in dienstliche Ladekosten,
             # nicht in den E-Mobilitäts-Pool der eigenen Anlage.
-            if (inv.parameter or {}).get("ist_dienstlich", False):
+            if ist_dienstlich(inv):
                 continue
             if inv.typ == "e-auto":
                 d["eauto_km"] += data.get("km_gefahren", 0) or 0

--- a/eedc/backend/api/routes/cockpit/social.py
+++ b/eedc/backend/api/routes/cockpit/social.py
@@ -31,6 +31,7 @@ from backend.core.field_definitions import (
 from backend.utils.sonstige_positionen import berechne_sonstige_summen
 from backend.services.community_service import get_region_from_plz
 from backend.api.routes.cockpit._shared import MONATSNAMEN
+from backend.core.investition_parameter import ist_dienstlich
 
 router = APIRouter()
 
@@ -156,7 +157,7 @@ async def get_share_text(
                 get_wp_heizenergie_kwh(data) + (data.get("warmwasser_kwh", 0) or 0)
             )
             wp_strom += get_wp_strom_kwh(data, inv.parameter)
-        elif inv.typ in ("e-auto", "wallbox") and not (inv.parameter or {}).get("ist_dienstlich", False):
+        elif inv.typ in ("e-auto", "wallbox") and not ist_dienstlich(inv):
             emob_km += data.get("km_gefahren", 0) or 0
             emob_ladung += get_eauto_ladung_kwh(data)
             emob_pv_ladung += data.get("ladung_pv_kwh", 0) or 0
@@ -182,7 +183,7 @@ async def get_share_text(
     wp_cop = (wp_waerme / wp_strom) if wp_strom > 0 and wp_waerme > 0 else 0
 
     hat_emobilitaet = any(
-        i.typ in ("e-auto", "wallbox") and not (i.parameter or {}).get("ist_dienstlich", False)
+        i.typ in ("e-auto", "wallbox") and not ist_dienstlich(i)
         for i in investitionen
     )
     emob_pv_anteil = (emob_pv_ladung / emob_ladung * 100) if emob_ladung > 0 else 0

--- a/eedc/backend/api/routes/cockpit/uebersicht.py
+++ b/eedc/backend/api/routes/cockpit/uebersicht.py
@@ -20,7 +20,7 @@ from backend.core.calculations import (
     CO2_FAKTOR_BENZIN_KG_LITER, berechne_ust_eigenverbrauch,
 )
 from backend.utils.sonstige_positionen import berechne_sonstige_summen
-from backend.core.investition_parameter import PARAM_E_AUTO, PARAM_WAERMEPUMPE
+from backend.core.investition_parameter import PARAM_E_AUTO, PARAM_WAERMEPUMPE, ist_dienstlich
 from backend.core.field_definitions import (
     get_pv_erzeugung_kwh,
     get_sonstiges_verbrauch_kwh,
@@ -234,7 +234,7 @@ async def get_cockpit_uebersicht(
             wp_strom += get_wp_strom_kwh(data, inv.parameter)
 
         elif inv.typ in ("e-auto", "wallbox"):
-            if (inv.parameter or {}).get("ist_dienstlich", False):
+            if ist_dienstlich(inv):
                 netz_kwh = data.get("ladung_netz_kwh", 0) or 0
                 pv_kwh = data.get("ladung_pv_kwh", 0) or 0
                 dienstlich_ladekosten_euro += (
@@ -410,7 +410,7 @@ async def get_cockpit_uebersicht(
         i for i in investitionen
         if i.typ in ("e-auto", "wallbox")
         and i.ist_aktiv_an(today)
-        and not (i.parameter or {}).get("ist_dienstlich", False)
+        and not ist_dienstlich(i)
     ]
     hat_emobilitaet = len(emob_invs) > 0
     emob_pv_anteil = (emob_pv_ladung / emob_ladung * 100) if emob_ladung > 0 else None

--- a/eedc/backend/api/routes/ha_export.py
+++ b/eedc/backend/api/routes/ha_export.py
@@ -35,6 +35,7 @@ from backend.core.investition_parameter import (
     PARAM_SPEICHER,
     PARAM_WAERMEPUMPE,
     PARAM_WAERMEPUMPE_DEFAULTS,
+    ist_dienstlich,
 )
 from backend.core.calculations import CO2_FAKTOR_STROM_KG_KWH
 from backend.core.wirtschaftlichkeit_defaults import (
@@ -235,7 +236,7 @@ async def calculate_anlage_sensors(
     waermepumpen = [i for i in investitionen if i.typ == "waermepumpe"]
     e_autos = [
         i for i in investitionen
-        if i.typ == "e-auto" and not (i.parameter or {}).get("ist_dienstlich", False)
+        if i.typ == "e-auto" and not ist_dienstlich(i)
     ]
     balkonkraftwerke = [i for i in investitionen if i.typ == "balkonkraftwerk"]
 

--- a/eedc/backend/core/investition_parameter.py
+++ b/eedc/backend/core/investition_parameter.py
@@ -233,3 +233,30 @@ LEGACY_PARAM_KEYS: Final[dict[str, str]] = {
     # Wechselrichter
     "leistung_ac_kw": "max_leistung_kw",  # nur im toten Schema
 }
+
+
+# ============================================================================
+# Robuste Flag-Lesehilfen
+# ============================================================================
+
+def ist_dienstlich(inv_or_parameter) -> bool:
+    """Truthy-Check für `ist_dienstlich` mit String-Drift-Schutz.
+
+    Akzeptiert ein Investition-Objekt oder direkt das parameter-Dict
+    (oder None). Schützt vor dem Klassiker, dass das Flag als String
+    `"true"` / `"false"` in der DB landet — Python wertet `"false"` sonst
+    als truthy aus und filtert das Auto fälschlich als Dienstwagen.
+    """
+    if inv_or_parameter is None:
+        return False
+    params = (
+        getattr(inv_or_parameter, "parameter", None)
+        if hasattr(inv_or_parameter, "parameter")
+        else inv_or_parameter
+    ) or {}
+    val = params.get(PARAM_E_AUTO["IST_DIENSTLICH"], False)
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.strip().lower() in ("true", "1", "yes", "ja")
+    return bool(val)

--- a/eedc/backend/services/daten_checker.py
+++ b/eedc/backend/services/daten_checker.py
@@ -23,6 +23,7 @@ from backend.models.investition import Investition, InvestitionMonatsdaten
 from backend.models.strompreis import Strompreis
 from backend.models.pvgis_prognose import PVGISPrognose
 from backend.utils.investition_filter import sort_investitionen_nach_typ
+from backend.core.investition_parameter import ist_dienstlich
 
 
 # ─── Enums & Dataclasses ────────────────────────────────────────────────────
@@ -467,7 +468,7 @@ class DatenChecker:
 
             elif inv.typ == "e-auto":
                 # Dienstwagen: keine PV-Ladungs-/ROI-Checks (kein PV-Bezug, kein Invest)
-                if param.get("ist_dienstlich"):
+                if ist_dienstlich(param):
                     continue
                 if not param.get("km_jahr") and not param.get("verbrauch_kwh_100km"):
                     ergebnisse.append(CheckErgebnis(
@@ -1008,8 +1009,7 @@ class DatenChecker:
             # für Dienstwagen ebenfalls übersprungen werden. (Joachim-PN
             # 2026-05-04: ID.4 als Dienstwagen meldete trotzdem kWh-Counter
             # fehlt.)
-            param = inv.parameter or {}
-            if inv.typ == "e-auto" and param.get("ist_dienstlich"):
+            if inv.typ == "e-auto" and ist_dienstlich(inv):
                 continue
 
             inv_data = inv_map.get(str(inv.id), {}) or {}

--- a/eedc/backend/tests/fixtures/local/.gitignore
+++ b/eedc/backend/tests/fixtures/local/.gitignore
@@ -1,0 +1,5 @@
+# Alles in diesem Ordner ist lokal — nicht in git tracken
+*
+# außer dieser .gitignore und der README
+!.gitignore
+!README.md

--- a/eedc/backend/tests/fixtures/local/README.md
+++ b/eedc/backend/tests/fixtures/local/README.md
@@ -1,0 +1,15 @@
+# Lokale Test-Fixtures
+
+Dieser Ordner ist per `.gitignore` aus dem Repo ausgeschlossen — alles ausser
+dieser README und `.gitignore` selbst.
+
+Hier kannst du echte eedc-Backup-Exporte ablegen, gegen die Tests laufen
+sollen (z.B. zur Diagnose eines konkreten User-Setups), ohne dass
+personenbezogene Daten in git wandern.
+
+## Verwendung
+
+Speichere deine Backup-Datei als `backup.json` in diesem Ordner. `test_H8_optional_aus_lokalem_backup`
+in [test_emob_km_uebersicht_bug.py](../../test_emob_km_uebersicht_bug.py)
+lädt sie automatisch und prüft das Cockpit-Übersicht-Verhalten gegen die
+ungefilterte IMD-Summe. Ohne Datei → Test wird übersprungen.

--- a/eedc/backend/tests/test_emob_km_uebersicht_bug.py
+++ b/eedc/backend/tests/test_emob_km_uebersicht_bug.py
@@ -1,0 +1,394 @@
+"""
+Reproduktion: User meldet "Cockpit-Übersicht-Kachel E-Mobilität zeigt
+Gefahrene km = 0", obwohl im E-Auto-Detail-Tab km für die gleichen Monate
+sichtbar sind und die KPI "Gefahren" eine echte Zahl liefert (sl@osyscon
+2026-05-17).
+
+IMD enthält `verbrauch_daten.km_gefahren` per E-Auto-IMD. Beide Code-Pfade
+(`/cockpit/uebersicht` und `/dashboard/e-auto`) lesen exakt dasselbe Feld
+unter denselben aktiv-Filtern.
+
+Hypothesen, die wir hier durchspielen:
+
+  H1: ist_dienstlich=False, km gepflegt              → emob_km > 0  (Baseline)
+  H2: ist_dienstlich=True,  km gepflegt              → emob_km == 0 (erwartet)
+  H3: ist_dienstlich="false" (String!), km gepflegt  → erwartet emob_km > 0,
+        aber Python-Bug: `if "false":` ist truthy → fällt in Dienstlich-Zweig
+        → emob_km == 0 (String-vs-Bool-Drift)
+  H4: ist_dienstlich="true"  (String!), km gepflegt  → emob_km == 0  (analog truthy)
+  H5: parameter == None,                       km    → emob_km > 0
+  H6: Wallbox nicht-dienstlich + E-Auto nicht-dienstlich mit km → emob_km > 0
+      (Reproduktion des Screenshot-Szenarios)
+
+Standalone-Runner, analog test_emob_pool_komponenten.py:
+
+    eedc/backend/venv/bin/python eedc/backend/tests/test_emob_km_uebersicht_bug.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import traceback
+from contextlib import asynccontextmanager
+from datetime import date
+from pathlib import Path
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine  # noqa: E402
+
+from backend.core.database import Base  # noqa: E402
+from backend.models import (  # noqa: E402, F401
+    Anlage, Investition, InvestitionMonatsdaten, Monatsdaten,
+)
+
+
+@asynccontextmanager
+async def _session_ctx():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    session = Session()
+    try:
+        yield session
+    finally:
+        await session.close()
+        await engine.dispose()
+
+
+async def _call_uebersicht(anlage_id: int, db: AsyncSession):
+    from backend.api.routes.cockpit.uebersicht import get_cockpit_uebersicht
+    return await get_cockpit_uebersicht(anlage_id=anlage_id, jahr=None, db=db)
+
+
+async def _seed_basis(db: AsyncSession) -> int:
+    anlage = Anlage(anlagenname="Test", leistung_kwp=10.0)
+    db.add(anlage)
+    await db.flush()
+    db.add(Monatsdaten(
+        anlage_id=anlage.id, jahr=2026, monat=4,
+        netzbezug_kwh=100.0, einspeisung_kwh=200.0,
+    ))
+    return anlage.id
+
+
+async def _seed_eauto(db: AsyncSession, anlage_id: int, parameter: dict | None,
+                     km: int = 3000, ladung_kwh: float = 365.0) -> int:
+    inv = Investition(
+        anlage_id=anlage_id, typ="e-auto",
+        bezeichnung="Test E-Auto",
+        anschaffungsdatum=date(2024, 1, 1),
+        parameter=parameter,
+    )
+    db.add(inv)
+    await db.flush()
+    db.add(InvestitionMonatsdaten(
+        investition_id=inv.id, jahr=2026, monat=4,
+        verbrauch_daten={
+            "ladung_kwh": ladung_kwh,
+            "ladung_pv_kwh": ladung_kwh * 0.99,
+            "ladung_netz_kwh": ladung_kwh * 0.01,
+            "km_gefahren": km,
+        },
+    ))
+    return inv.id
+
+
+# ── Tests ──
+
+
+async def test_H1_baseline_privat_bool_false():
+    """Klassischer Fall: ist_dienstlich=False (echtes Bool), km gepflegt."""
+    async with _session_ctx() as db:
+        anlage_id = await _seed_basis(db)
+        await _seed_eauto(db, anlage_id, parameter={"ist_dienstlich": False})
+        await db.commit()
+        result = await _call_uebersicht(anlage_id, db)
+        assert result.emob_km == 3000, f"erwartet 3000, war {result.emob_km}"
+
+
+async def test_H2_dienstwagen_bool_true():
+    """Dienstwagen mit ist_dienstlich=True → km werden ausgefiltert."""
+    async with _session_ctx() as db:
+        anlage_id = await _seed_basis(db)
+        await _seed_eauto(db, anlage_id, parameter={"ist_dienstlich": True})
+        await db.commit()
+        result = await _call_uebersicht(anlage_id, db)
+        assert result.emob_km == 0, f"Dienstwagen darf nicht zählen, war {result.emob_km}"
+
+
+async def test_H3_string_false_sollte_privat_sein():
+    """ist_dienstlich='false' (String) → Python: bool('false') == True →
+    fällt im aktuellen Code in Dienstlich-Zweig → km == 0 obwohl gepflegt.
+    Wenn dieser Test FAIL ist, haben wir den Bug reproduziert."""
+    async with _session_ctx() as db:
+        anlage_id = await _seed_basis(db)
+        await _seed_eauto(db, anlage_id, parameter={"ist_dienstlich": "false"})
+        await db.commit()
+        result = await _call_uebersicht(anlage_id, db)
+        assert result.emob_km == 3000, (
+            f"ist_dienstlich='false' sollte als 'nicht dienstlich' interpretiert "
+            f"werden → 3000 km, war {result.emob_km}"
+        )
+
+
+async def test_H4_string_true_dienstwagen():
+    """ist_dienstlich='true' (String) → soll als Dienstwagen behandelt werden."""
+    async with _session_ctx() as db:
+        anlage_id = await _seed_basis(db)
+        await _seed_eauto(db, anlage_id, parameter={"ist_dienstlich": "true"})
+        await db.commit()
+        result = await _call_uebersicht(anlage_id, db)
+        assert result.emob_km == 0, f"Dienstwagen via String, erwartet 0, war {result.emob_km}"
+
+
+async def test_H5_parameter_none():
+    """parameter is None → kein ist_dienstlich-Key → muss als 'privat' gelten."""
+    async with _session_ctx() as db:
+        anlage_id = await _seed_basis(db)
+        await _seed_eauto(db, anlage_id, parameter=None)
+        await db.commit()
+        result = await _call_uebersicht(anlage_id, db)
+        assert result.emob_km == 3000, f"erwartet 3000, war {result.emob_km}"
+
+
+async def test_H7_dienstwagen_plus_nichtdienstliche_wallbox():
+    """Strukturmuster: dienstliches E-Auto (ist_dienstlich=True), private
+    Wallbox (ist_dienstlich nicht gesetzt → wird wie False behandelt).
+
+    Erwartung: emob_km = 0 (E-Auto-Zweig im Dienstlich-Filter
+    rausgefiltert), aber emob_ladung_kwh > 0 (Wallbox läuft durch den Pool).
+    Das ist das designte Verhalten — der User sieht eine asymmetrische
+    Kachel (Ladung sichtbar, km nicht), weil Wallbox-Loadpoint und
+    E-Auto-Vehicle unterschiedlich gefiltert werden, obwohl sie denselben
+    Strom messen."""
+    async with _session_ctx() as db:
+        anlage_id = await _seed_basis(db)
+        ea = Investition(
+            anlage_id=anlage_id, typ="e-auto",
+            bezeichnung="Test-Dienstwagen",
+            anschaffungsdatum=date(2024, 1, 1),
+            parameter={"ist_dienstlich": True},
+        )
+        wb = Investition(
+            anlage_id=anlage_id, typ="wallbox",
+            bezeichnung="Test-Wallbox",
+            anschaffungsdatum=date(2024, 1, 1),
+            parameter={},  # kein ist_dienstlich-Key
+        )
+        db.add_all([ea, wb])
+        await db.flush()
+        db.add(InvestitionMonatsdaten(
+            investition_id=ea.id, jahr=2026, monat=4,
+            verbrauch_daten={"km_gefahren": 2500, "ladung_kwh": 20.0},
+        ))
+        db.add(InvestitionMonatsdaten(
+            investition_id=wb.id, jahr=2026, monat=4,
+            verbrauch_daten={"ladung_kwh": 350.0, "ladung_pv_kwh": 340.0},
+        ))
+        await db.commit()
+
+        result = await _call_uebersicht(anlage_id, db)
+        assert result.emob_km == 0, (
+            f"Dienstwagen → km gefiltert, erwartet 0, war {result.emob_km}"
+        )
+        assert 340 <= result.emob_ladung_kwh <= 360, (
+            f"Wallbox-Pool muss durchkommen, war {result.emob_ladung_kwh}"
+        )
+
+
+async def test_H8_optional_aus_lokalem_backup():
+    """Optional: liest ein eedc-Backup-JSON aus einem nicht-versionierten
+    Pfad ein und prüft, dass die Cockpit-Übersicht für die enthaltenen
+    Anlagen zumindest *konsistent* mit dem reinen IMD-Aggregat
+    übereinstimmt. Wenn keine Backup-Datei vorhanden ist: SKIP.
+
+    Pfad: eedc/backend/tests/fixtures/local/backup.json
+    (per .gitignore ausgeschlossen)
+    """
+    fixture = Path(__file__).parent / "fixtures" / "local" / "backup.json"
+    if not fixture.exists():
+        print(f"     (skip: {fixture.relative_to(Path(__file__).parents[2])} nicht vorhanden)")
+        return
+
+    import json
+    payload = json.loads(fixture.read_text(encoding="utf-8"))
+
+    async with _session_ctx() as db:
+        anlage_id = await _load_backup_anlage(db, payload)
+        result = await _call_uebersicht(anlage_id, db)
+
+        # Vergleichswert: dieselbe Aggregation, aber direkt aus IMD ohne
+        # Dienstlich-Filter (so wie der E-Auto-Detail-Tab es macht).
+        from sqlalchemy import select
+        from backend.models import Investition, InvestitionMonatsdaten
+        e_autos = (await db.execute(
+            select(Investition).where(
+                Investition.anlage_id == anlage_id,
+                Investition.typ == "e-auto",
+            )
+        )).scalars().all()
+        ea_ids = [e.id for e in e_autos]
+        imds = (await db.execute(
+            select(InvestitionMonatsdaten).where(
+                InvestitionMonatsdaten.investition_id.in_(ea_ids)
+            )
+        )).scalars().all() if ea_ids else []
+        km_ungefiltert = sum(
+            (imd.verbrauch_daten or {}).get("km_gefahren", 0) or 0
+            for imd in imds
+        )
+
+        # Falls min. ein E-Auto dienstlich ist: Übersicht zeigt 0 km, aber
+        # ungefilterte Summe > 0 → das ist genau der Screenshot-Effekt.
+        dienstlich_vorhanden = any(
+            (e.parameter or {}).get("ist_dienstlich") is True for e in e_autos
+        )
+        if dienstlich_vorhanden and km_ungefiltert > 0:
+            assert result.emob_km < km_ungefiltert, (
+                f"Erwartung Screenshot-Szenario: Übersicht-km ({result.emob_km}) "
+                f"< Detail-Tab-km ({km_ungefiltert}), Dienstwagen wird gefiltert"
+            )
+            print(f"     (Backup-Anlage: Übersicht={result.emob_km} km, "
+                  f"Detail-Tab-Summe={km_ungefiltert:.0f} km → Dienstwagen-Filter aktiv)")
+        else:
+            assert result.emob_km == km_ungefiltert, (
+                f"Ohne Dienstwagen-Filter müssen Übersicht und Detail-Tab "
+                f"übereinstimmen — war {result.emob_km} vs. {km_ungefiltert}"
+            )
+
+
+async def _load_backup_anlage(db: AsyncSession, payload: dict) -> int:
+    """Lädt nur die Felder, die der Test braucht — bewusst minimal, damit
+    keine Side-Effects (Tarife, PVGIS etc.) das Verhalten verändern."""
+    a = payload.get("anlage") or {}
+    anlage = Anlage(
+        anlagenname=a.get("anlagenname") or "Imported",
+        leistung_kwp=a.get("leistung_kwp") or 0.0,
+    )
+    db.add(anlage)
+    await db.flush()
+
+    def _parse_date(s):
+        return date.fromisoformat(s) if s else None
+
+    def _add_inv(inv_data, parent_id=None):
+        inv = Investition(
+            anlage_id=anlage.id,
+            typ=inv_data["typ"],
+            bezeichnung=inv_data.get("bezeichnung") or inv_data["typ"],
+            anschaffungsdatum=_parse_date(inv_data.get("anschaffungsdatum")),
+            stilllegungsdatum=_parse_date(inv_data.get("stilllegungsdatum")),
+            parameter=inv_data.get("parameter"),
+        )
+        db.add(inv)
+        return inv
+
+    invs_to_persist: list[tuple[Investition, list[dict]]] = []
+    for inv_data in payload.get("investitionen") or []:
+        inv = _add_inv(inv_data)
+        invs_to_persist.append((inv, inv_data.get("monatsdaten") or []))
+        for child in inv_data.get("children") or []:
+            child_inv = _add_inv(child)
+            invs_to_persist.append((child_inv, child.get("monatsdaten") or []))
+
+    await db.flush()
+    for inv, md_list in invs_to_persist:
+        for md in md_list:
+            db.add(InvestitionMonatsdaten(
+                investition_id=inv.id,
+                jahr=md["jahr"], monat=md["monat"],
+                verbrauch_daten=md.get("verbrauch_daten") or {},
+            ))
+    # Basis-Monatsdaten (für Anlagen-Energiebilanz, sonst null-Felder)
+    for md in payload.get("monatsdaten") or []:
+        db.add(Monatsdaten(
+            anlage_id=anlage.id,
+            jahr=md["jahr"], monat=md["monat"],
+            einspeisung_kwh=md.get("einspeisung_kwh") or 0.0,
+            netzbezug_kwh=md.get("netzbezug_kwh") or 0.0,
+        ))
+    await db.commit()
+    return anlage.id
+
+
+async def test_H6_szenario_screenshot_eauto_plus_wallbox():
+    """Screenshot-Reproduktion: E-Auto + Wallbox, beide nicht dienstlich.
+    E-Auto trägt km, Wallbox trägt ladung_kwh (Loadpoint-Sicht).
+    Erwartung: emob_km > 0 und emob_ladung_kwh > 0 gleichzeitig."""
+    async with _session_ctx() as db:
+        anlage_id = await _seed_basis(db)
+        # E-Auto: km + kleine Vehicle-Sicht-Ladung (oft schlechter gepflegt)
+        ea_id = await _seed_eauto(
+            db, anlage_id,
+            parameter={"ist_dienstlich": False},
+            km=3000, ladung_kwh=360.0,
+        )
+        # Wallbox: Loadpoint-Wahrheit, leicht höher
+        wb = Investition(
+            anlage_id=anlage_id, typ="wallbox",
+            bezeichnung="Wallbox",
+            anschaffungsdatum=date(2024, 1, 1),
+            parameter={"ist_dienstlich": False},
+        )
+        db.add(wb)
+        await db.flush()
+        db.add(InvestitionMonatsdaten(
+            investition_id=wb.id, jahr=2026, monat=4,
+            verbrauch_daten={
+                "ladung_kwh": 370.0,
+                "ladung_pv_kwh": 366.0,
+                "ladung_netz_kwh": 4.0,
+            },
+        ))
+        await db.commit()
+
+        result = await _call_uebersicht(anlage_id, db)
+        assert result.emob_km == 3000, (
+            f"Screenshot-Bug: km müssen ankommen, war {result.emob_km}"
+        )
+        assert result.emob_ladung_kwh > 360, (
+            f"Ladung max-Pool > 360, war {result.emob_ladung_kwh}"
+        )
+
+
+# ── Runner ──
+
+
+_TESTS = [
+    test_H1_baseline_privat_bool_false,
+    test_H2_dienstwagen_bool_true,
+    test_H3_string_false_sollte_privat_sein,
+    test_H4_string_true_dienstwagen,
+    test_H5_parameter_none,
+    test_H6_szenario_screenshot_eauto_plus_wallbox,
+    test_H7_dienstwagen_plus_nichtdienstliche_wallbox,
+    test_H8_optional_aus_lokalem_backup,
+]
+
+
+async def _main() -> int:
+    failures = 0
+    for fn in _TESTS:
+        try:
+            await fn()
+            print(f"OK   {fn.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {fn.__name__}: {e}")
+        except Exception as e:
+            failures += 1
+            print(f"ERR  {fn.__name__}: {type(e).__name__}: {e}")
+            traceback.print_exc()
+    if failures:
+        print(f"\n{failures}/{len(_TESTS)} Tests fehlgeschlagen.")
+        return 1
+    print(f"\nAlle {len(_TESTS)} Tests grün.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(_main()))


### PR DESCRIPTION
## Symptom

User-Report: in der Cockpit-Übersicht zeigt die E-Mobilitäts-Kachel
`Gefahrene km = 0`, obwohl der E-Auto-Detail-Tab für dieselben Monate
echte km-Werte aus `InvestitionMonatsdaten.verbrauch_daten.km_gefahren`
zeigt.

## Root Cause

Alle 17 Lesestellen prüften das Flag mit

```python
(inv.parameter or {}).get("ist_dienstlich", False)
```

Wenn `parameter["ist_dienstlich"]` als String `"false"` in der DB steht
(z. B. aus einem alten Form-Submit, der nicht in Bool gecastet hat),
liefert `.get(...)` den String zurück — und `if "false":` ist in Python
**truthy**. Der Code landet im Dienstlich-Zweig, km werden aus der
Aggregation ausgefiltert. Die Wallbox-Ladung läuft trotzdem durch den
Pool, daher zeigt die Kachel asymmetrisch: Ladung sichtbar, km = 0.

## Fix

Neuer Helper [`ist_dienstlich(inv_or_parameter)`](eedc/backend/core/investition_parameter.py)
kapselt die Lese-Logik:

- akzeptiert Investition-Objekt oder direkt `parameter`-Dict (oder `None`)
- echtes Bool → unverändert
- String `"true"/"1"/"yes"/"ja"` → `True`, alles andere → `False`
- defensiver `bool(...)`-Fallback für Sonderfälle

Alle 17 Lesestellen über 7 Dateien auf den Helper umgestellt:

- `api/routes/aktueller_monat.py`
- `api/routes/aussichten.py`
- `api/routes/ha_export.py`
- `api/routes/cockpit/uebersicht.py`
- `api/routes/cockpit/komponenten.py`
- `api/routes/cockpit/social.py`
- `services/daten_checker.py`

## Test

[`tests/test_emob_km_uebersicht_bug.py`](eedc/backend/tests/test_emob_km_uebersicht_bug.py) mit 8 Szenarien:

| Test | Eingabe | Erwartung |
|---|---|---|
| H1 | `ist_dienstlich = False` (Bool) | km werden gezählt |
| H2 | `ist_dienstlich = True` (Bool) | km werden gefiltert |
| H3 | `ist_dienstlich = "false"` (String) | km werden gezählt — **reproduzierte ohne Fix den Bug** |
| H4 | `ist_dienstlich = "true"` (String) | km werden gefiltert |
| H5 | `parameter = None` | km werden gezählt |
| H6 | E-Auto + Wallbox, beide privat | Pool-max, km und Ladung > 0 |
| H7 | E-Auto dienstlich + Wallbox privat | km = 0, Ladung > 0 (Screenshot-Muster) |
| H8 | Optionaler Loader für lokales eedc-Backup | skip ohne Datei, sonst Konsistenz-Check |

Lokale Real-Daten-Fixtures kommen in `tests/fixtures/local/` (per `.gitignore` ausgeschlossen — README + .gitignore selbst getrackt).

## Verifikation

```bash
eedc/backend/venv/bin/python eedc/backend/tests/test_emob_km_uebersicht_bug.py
# Alle 8 Tests grün.

eedc/backend/venv/bin/python eedc/backend/tests/test_emob_pool_komponenten.py
# Alle 4 Tests grün (bestehender E-Mob-Pool-Test bleibt grün).
```

## Test plan

- [ ] CI grün
- [ ] Smoke-Test im Add-on: Cockpit-Übersicht-Kachel zeigt km-Werte konsistent zum Detail-Tab, auch wenn `parameter.ist_dienstlich` historisch als String gespeichert wurde
- [ ] Dienstwagen-Filter funktioniert weiterhin korrekt für echtes Bool `True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)