### PR TITLE
feat(speicher): Wirtschaftlichkeit mit PV-/Netz-Anteil — Etappe B (#264)

### DIFF
--- a/eedc/backend/api/routes/aussichten.py
+++ b/eedc/backend/api/routes/aussichten.py
@@ -38,6 +38,8 @@ from backend.services.speicher_wirtschaftlichkeit import (
 from backend.core.investition_parameter import (
     PARAM_E_AUTO,
     PARAM_E_AUTO_DEFAULTS,
+    PARAM_SPEICHER,
+    PARAM_SPEICHER_DEFAULTS,
     PARAM_WAERMEPUMPE,
     PARAM_WAERMEPUMPE_DEFAULTS,
 )
@@ -1425,12 +1427,69 @@ async def get_finanz_prognose(
     # =====================================================================
     komponenten_beitraege = []
 
+    # Etappe B (#264): Speicher-Spread-Service bekommt jetzt PV/Netz-Anteil.
+    # Wir leiten den historischen Netz-Anteil an der Ladung ab und projizieren
+    # ihn auf den prognostizierten Speicher-Beitrag. Ohne IST-Netzladung
+    # (z. B. reiner PV-Speicher) bleibt das Verhalten exakt wie bisher.
+    speicher_ladung_hist_total = 0.0
+    speicher_netzladung_hist_total = 0.0
+    if speicher:
+        for sp in speicher:
+            for (inv_id, jhr, mon), daten in historische_inv_daten.items():
+                if inv_id != sp.id or not sp.ist_aktiv_im_monat(jhr, mon):
+                    continue
+                speicher_ladung_hist_total += float(daten.get("ladung_kwh") or 0)
+                speicher_netzladung_hist_total += float(
+                    daten.get("ladung_netz_kwh")
+                    or daten.get("speicher_ladung_netz_kwh")
+                    or 0
+                )
+
+    speicher_netz_anteil = (
+        speicher_netzladung_hist_total / speicher_ladung_hist_total
+        if speicher_ladung_hist_total > 0 else 0.0
+    )
+    speicher_wirkungsgrad_avg = (
+        sum(
+            (sp.parameter or {}).get(
+                PARAM_SPEICHER["WIRKUNGSGRAD_PROZENT"],
+                PARAM_SPEICHER_DEFAULTS["wirkungsgrad_prozent"],
+            )
+            for sp in speicher
+        ) / len(speicher)
+        if speicher else PARAM_SPEICHER_DEFAULTS["wirkungsgrad_prozent"]
+    )
+    # Ladepreis nur bei arbitragefähigen Speichern relevant — sonst ist die
+    # Netzladung kostenneutrale Durchleitung (z. B. Backup-Ladung).
+    arbitrage_speicher = [
+        sp for sp in speicher
+        if (sp.parameter or {}).get(PARAM_SPEICHER["ARBITRAGE_FAEHIG"])
+    ]
+    speicher_lade_preis_cent = (
+        sum(
+            (sp.parameter or {}).get(
+                PARAM_SPEICHER["LADE_DURCHSCHNITTSPREIS_CENT"],
+                PARAM_SPEICHER_DEFAULTS["lade_durchschnittspreis_cent"],
+            )
+            for sp in arbitrage_speicher
+        ) / len(arbitrage_speicher)
+        if arbitrage_speicher else None
+    )
+    # Aus Entladung auf Ladung zurückrechnen (η-Verluste), daraus den
+    # projizierten Netz-Anteil-kWh der Prognoseperiode bestimmen.
+    speicher_wirkungsgrad_frac = max(0.5, speicher_wirkungsgrad_avg / 100)
+    prog_speicher_ladung = jahres_speicher_beitrag / speicher_wirkungsgrad_frac
+    prog_speicher_netzladung = prog_speicher_ladung * speicher_netz_anteil
+
     # Speicher (Drift-Audit D: Spread-Modell statt Voll-Strompreis)
     if speicher:
         speicher_ersparnis = berechne_speicher_ersparnis(
             entladung_kwh=jahres_speicher_beitrag,
             bezug_preis_cent=netzbezug_preis,
             einspeise_verg_cent=einspeiseverguetung,
+            ladung_netz_kwh=prog_speicher_netzladung,
+            wirkungsgrad_prozent=speicher_wirkungsgrad_avg,
+            lade_preis_cent=speicher_lade_preis_cent,
         ).ersparnis_euro
         for sp in speicher:
             komponenten_beitraege.append(KomponentenBeitragSchema(
@@ -1530,11 +1589,16 @@ async def get_finanz_prognose(
     else:
         datenquellen.insert(0, "pvgis-tmy")
 
-    # Drift-Audit D: Spread-Modell für Speicher + V2H (Bezug − Einspeise)
+    # Drift-Audit D: Spread-Modell für Speicher + V2H (Bezug − Einspeise).
+    # Etappe B (#264): mit PV/Netz-Anteil aus der historischen Aufteilung
+    # (siehe Speicher-Netz-Anteil-Block oben — gleiche Args).
     speicher_ersparnis_euro = berechne_speicher_ersparnis(
         entladung_kwh=jahres_speicher_beitrag,
         bezug_preis_cent=netzbezug_preis,
         einspeise_verg_cent=einspeiseverguetung,
+        ladung_netz_kwh=prog_speicher_netzladung,
+        wirkungsgrad_prozent=speicher_wirkungsgrad_avg,
+        lade_preis_cent=speicher_lade_preis_cent,
     ).ersparnis_euro
     v2h_ersparnis_euro = berechne_v2h_ersparnis(
         v2h_entladung_kwh=jahres_v2h_beitrag,

--- a/eedc/backend/api/routes/investitionen.py
+++ b/eedc/backend/api/routes/investitionen.py
@@ -43,6 +43,8 @@ from backend.core.wirtschaftlichkeit_defaults import (
     NETZBEZUG_DEFAULT_CENT,
 )
 from backend.services.speicher_wirtschaftlichkeit import (
+    SpeicherIstAggregat,
+    aggregiere_speicher_ist,
     berechne_speicher_ersparnis,
     berechne_v2h_ersparnis,
 )
@@ -770,6 +772,32 @@ async def get_roi_dashboard(
     gesamt_einsparung = 0.0
     gesamt_co2 = 0.0
 
+    # Etappe B (#264): Speicher-IST-Aggregate einmal laden — sowohl für
+    # DC-gekoppelte (Phase 3) als auch standalone AC-Speicher (Phase 5).
+    # Pro Speicher wird `entladung_kwh` und `ladung_netz_kwh` aus allen
+    # aktiven Monatsdaten summiert und auf ein Jahr hochgerechnet, damit
+    # das ROI-Modell die echte PV/Netz-Aufteilung nutzen kann statt der
+    # impliziten 100%-PV-Annahme.
+    speicher_invs_alle = [i for i in investitionen if i.typ == InvestitionTyp.SPEICHER.value]
+    speicher_ist_by_inv: dict[int, "SpeicherIstAggregat | None"] = {}
+    if speicher_invs_alle:
+        speicher_ids = [i.id for i in speicher_invs_alle]
+        sp_imd_result = await db.execute(
+            select(InvestitionMonatsdaten)
+            .where(InvestitionMonatsdaten.investition_id.in_(speicher_ids))
+        )
+        sp_imd_by_inv: dict[int, list[InvestitionMonatsdaten]] = {}
+        for imd in sp_imd_result.scalars().all():
+            sp_imd_by_inv.setdefault(imd.investition_id, []).append(imd)
+        for sp in speicher_invs_alle:
+            # Filter analog #236: Stilllegung/Inbetriebnahme respektieren.
+            aktive_daten = [
+                (imd.verbrauch_daten or {})
+                for imd in sp_imd_by_inv.get(sp.id, [])
+                if sp.ist_aktiv_im_monat(imd.jahr, imd.monat)
+            ]
+            speicher_ist_by_inv[sp.id] = aggregiere_speicher_ist(aktive_daten)
+
     # PV-Einsparung einmal berechnen (wird auf Module verteilt)
     pv_jahres_einsparung, pv_co2, pv_detail = await berechne_pv_einsparung_aus_monatsdaten()
 
@@ -867,19 +895,39 @@ async def get_roi_dashboard(
             wirkungsgrad = params.get(PARAM_SPEICHER["WIRKUNGSGRAD_PROZENT"], PARAM_SPEICHER_DEFAULTS["wirkungsgrad_prozent"])
             # Bug #5 v3.25.0: vorher 'nutzt_arbitrage' (toter Schema-Key), Form/Wizard schreiben 'arbitrage_faehig'.
             nutzt_arbitrage = params.get(PARAM_SPEICHER["ARBITRAGE_FAEHIG"], PARAM_SPEICHER_DEFAULTS["arbitrage_faehig"])
+            lade_preis_dc = params.get(
+                PARAM_SPEICHER["LADE_DURCHSCHNITTSPREIS_CENT"],
+                PARAM_SPEICHER_DEFAULTS["lade_durchschnittspreis_cent"],
+            )
 
+            ist_aggregat = speicher_ist_by_inv.get(inv.id)
             result = berechne_speicher_einsparung(
                 kapazitaet_kwh=kapazitaet,
                 wirkungsgrad_prozent=wirkungsgrad,
                 netzbezug_preis_cent=strompreis_cent,
                 einspeiseverguetung_cent=einspeiseverguetung_cent,
                 nutzt_arbitrage=nutzt_arbitrage,
+                lade_preis_cent=lade_preis_dc,
+                ist_entladung_kwh=ist_aggregat.entladung_kwh_jahr if ist_aggregat else None,
+                ist_ladung_netz_kwh=ist_aggregat.ladung_netz_kwh_jahr if ist_aggregat else 0,
             )
             inv_einsparung = result.jahres_einsparung_euro
             inv_co2 = result.co2_einsparung_kg
             system_einsparung += inv_einsparung
             system_co2 += inv_co2
 
+            komp_detail: dict[str, Any] = {'kapazitaet_kwh': kapazitaet, 'dc_gekoppelt': True}
+            if ist_aggregat is not None:
+                komp_detail.update({
+                    'modus': 'ist',
+                    'ist_entladung_kwh_jahr': round(ist_aggregat.entladung_kwh_jahr, 1),
+                    'ist_ladung_netz_kwh_jahr': round(ist_aggregat.ladung_netz_kwh_jahr, 1),
+                    'ist_monate': ist_aggregat.anzahl_monate,
+                    'pv_anteil_euro': result.pv_anteil_euro,
+                    'netz_anteil_euro': result.arbitrage_anteil_euro,
+                })
+            else:
+                komp_detail['modus'] = 'prognose'
             komponenten.append(ROIKomponente(
                 investition_id=inv.id,
                 bezeichnung=f"{inv.bezeichnung} ({kapazitaet} kWh)",
@@ -889,7 +937,7 @@ async def get_roi_dashboard(
                 relevante_kosten=inv_kosten - inv_alternativ,
                 einsparung=round(inv_einsparung, 2),
                 co2_einsparung_kg=round(inv_co2, 1),
-                detail={'kapazitaet_kwh': kapazitaet, 'dc_gekoppelt': True}
+                detail=komp_detail,
             ))
 
         # System-ROI berechnen
@@ -988,6 +1036,7 @@ async def get_roi_dashboard(
             lade_preis = params.get(PARAM_SPEICHER["LADE_DURCHSCHNITTSPREIS_CENT"], PARAM_SPEICHER_DEFAULTS["lade_durchschnittspreis_cent"])
             entlade_preis = params.get(PARAM_SPEICHER["ENTLADE_VERMIEDENER_PREIS_CENT"], PARAM_SPEICHER_DEFAULTS["entlade_vermiedener_preis_cent"])
 
+            ist_aggregat = speicher_ist_by_inv.get(inv.id)
             result = berechne_speicher_einsparung(
                 kapazitaet_kwh=kapazitaet,
                 wirkungsgrad_prozent=wirkungsgrad,
@@ -996,6 +1045,8 @@ async def get_roi_dashboard(
                 nutzt_arbitrage=nutzt_arbitrage,
                 lade_preis_cent=lade_preis,
                 entlade_preis_cent=entlade_preis,
+                ist_entladung_kwh=ist_aggregat.entladung_kwh_jahr if ist_aggregat else None,
+                ist_ladung_netz_kwh=ist_aggregat.ladung_netz_kwh_jahr if ist_aggregat else 0,
             )
             jahres_einsparung = result.jahres_einsparung_euro
             co2_einsparung = result.co2_einsparung_kg
@@ -1004,7 +1055,17 @@ async def get_roi_dashboard(
                 'pv_anteil_euro': result.pv_anteil_euro,
                 'arbitrage_anteil_euro': result.arbitrage_anteil_euro,
                 'hinweis': 'AC-gekoppelter Speicher',
+                'modus': 'ist' if ist_aggregat is not None else 'prognose',
             }
+            if ist_aggregat is not None:
+                detail.update({
+                    'ist_entladung_kwh_jahr': round(ist_aggregat.entladung_kwh_jahr, 1),
+                    'ist_ladung_netz_kwh_jahr': round(ist_aggregat.ladung_netz_kwh_jahr, 1),
+                    'ist_monate': ist_aggregat.anzahl_monate,
+                    # `arbitrage_anteil_euro` ist im IST-Modus der gemessene
+                    # Netz-Anteil-Vorteil (siehe calculations.berechne_speicher_einsparung).
+                    'netz_anteil_euro': result.arbitrage_anteil_euro,
+                })
 
         elif inv.typ == InvestitionTyp.E_AUTO.value:
             # Bugs #1, #2, #3, #4 v3.25.0: vorher las dieser Block aus toten Schema-Keys

--- a/eedc/backend/core/calculations.py
+++ b/eedc/backend/core/calculations.py
@@ -176,30 +176,71 @@ def berechne_speicher_einsparung(
     lade_preis_cent: float = 0,
     entlade_preis_cent: float = 0,
     zyklen_pro_jahr: int = SPEICHER_ZYKLEN_PRO_JAHR,
+    ist_entladung_kwh: Optional[float] = None,
+    ist_ladung_netz_kwh: float = 0,
 ) -> SpeicherEinsparung:
     """
-    Berechnet jährliche Speicher-Einsparung (Prognose).
+    Berechnet jährliche Speicher-Einsparung.
 
-    Ohne Arbitrage:
-        Einsparung = Zyklen × Kapazität × Wirkungsgrad × (Netzbezug - Einspeisung)
+    Modi (siehe Issue #264 Etappe B):
 
-    Mit Arbitrage (70/30 Modell):
-        70% PV-Anteil: Statt Einspeisung → Eigenverbrauch
-        30% Arbitrage: Netzladung mit günstigen Tarifen
+    1. **Prognose** (`ist_entladung_kwh=None`, Default) — wie bisher:
+       - Ohne Arbitrage: `Zyklen × Kapazität × η × (Bezug − Einspeisung)`
+       - Mit Arbitrage: fixes 70/30-Modell aus `lade_preis_cent` / `entlade_preis_cent`
+
+    2. **IST-basiert** (`ist_entladung_kwh` gepflegt): delegiert an den kanonischen
+       Spread-Service `speicher_wirtschaftlichkeit.berechne_speicher_ersparnis()`
+       — derselbe Helper, den Aussichten verwendet. Damit driften die beiden
+       Berechnungspfade (Aussichten ↔ Investitionen-ROI) im IST-Pfad nicht
+       mehr auseinander (Drift-Audit D). Der gemessene Netz-Anteil korrigiert
+       den Spread, sodass nicht mehr implizit 100 % PV-Ladung unterstellt wird.
 
     Args:
-        kapazitaet_kwh: Speicherkapazität in kWh
+        kapazitaet_kwh: Speicherkapazität in kWh (für Prognose)
         wirkungsgrad_prozent: Wirkungsgrad des Speichers (z.B. 95)
         netzbezug_preis_cent: Normaler Strompreis in Cent
         einspeiseverguetung_cent: Einspeisevergütung in Cent
-        nutzt_arbitrage: True wenn dynamische Tarife genutzt werden
-        lade_preis_cent: Typischer Ladungspreis bei Arbitrage (z.B. 12 ct nachts)
-        entlade_preis_cent: Typischer vermiedener Preis (z.B. 35 ct abends)
-        zyklen_pro_jahr: Anzahl Vollzyklen pro Jahr
+        nutzt_arbitrage: True wenn dynamische Tarife genutzt werden (Prognose-Modus)
+        lade_preis_cent: Ø-Ladepreis bei Arbitrage (z.B. 12 ct nachts)
+        entlade_preis_cent: Vermiedener Preis bei Arbitrage (z.B. 35 ct abends)
+        zyklen_pro_jahr: Anzahl Vollzyklen pro Jahr (Prognose-Modus)
+        ist_entladung_kwh: Tatsächliche Jahres-Entladung (aggregiert aus IMD) —
+            schaltet auf den Spread-Service-Pfad um.
+        ist_ladung_netz_kwh: Tatsächliche Jahres-Netzladung (für PV/Netz-Aufteilung)
 
     Returns:
-        SpeicherEinsparung: Berechnete Werte
+        SpeicherEinsparung mit gemappten pv_anteil_euro / arbitrage_anteil_euro.
     """
+    # --- IST-Modus: Delegation an den kanonischen Spread-Service ---
+    if ist_entladung_kwh is not None:
+        # Lokaler Import vermeidet eine Modul-Zyklen-Falle, falls calculations.py
+        # je in den Service zurückgezogen wird.
+        from backend.services.speicher_wirtschaftlichkeit import berechne_speicher_ersparnis
+
+        # Im Arbitrage-Modus liefert `lade_preis_cent` den Ø-Ladepreis; sonst None →
+        # Netzladung wird im Service als kostenneutral behandelt.
+        ladepreis = lade_preis_cent if nutzt_arbitrage and lade_preis_cent > 0 else None
+
+        result = berechne_speicher_ersparnis(
+            entladung_kwh=ist_entladung_kwh,
+            bezug_preis_cent=netzbezug_preis_cent,
+            einspeise_verg_cent=einspeiseverguetung_cent,
+            ladung_netz_kwh=ist_ladung_netz_kwh,
+            wirkungsgrad_prozent=wirkungsgrad_prozent,
+            lade_preis_cent=ladepreis,
+        )
+        # Der CO2-Vorteil bezieht sich auf die effektiv aus PV-Strom ersetzte
+        # Netzenergie — der Netz-Anteil ist nur Tarif-Arbitrage und spart kein CO2.
+        co2 = result.pv_anteil_entladung_kwh * CO2_FAKTOR_STROM_KG_KWH
+        return SpeicherEinsparung(
+            jahres_einsparung_euro=round(result.ersparnis_euro, 2),
+            nutzbare_speicherung_kwh=round(ist_entladung_kwh, 1),
+            pv_anteil_euro=round(result.pv_anteil_euro, 2),
+            arbitrage_anteil_euro=round(result.netz_anteil_euro, 2),
+            co2_einsparung_kg=round(co2, 1),
+        )
+
+    # --- Prognose-Modus (unverändert) ---
     wirkungsgrad = wirkungsgrad_prozent / 100
     nutzbare_speicherung = kapazitaet_kwh * zyklen_pro_jahr * wirkungsgrad
     standard_spread = netzbezug_preis_cent - einspeiseverguetung_cent

--- a/eedc/backend/services/speicher_wirtschaftlichkeit.py
+++ b/eedc/backend/services/speicher_wirtschaftlichkeit.py
@@ -13,13 +13,86 @@ nur der Differenzbetrag (Bezug − Einspeise).
 Gleiche Logik gilt für V2H: PV-Energie die ins Auto und dann via V2H zurück
 ins Haus fließt, hätte sonst eingespeist werden können → Spread.
 
-Limitierung: bei dynamischen Strompreisen / Arbitrage-Speicher ist der
-„Spread" zeitabhängig — siehe `arbitrage_gewinn` als separate Berechnung.
+Etappe B (Issue #264): Der Spread-Service unterscheidet jetzt PV- und
+Netz-Anteil der Entladung. Aus dem Netz geladene Energie hätte nicht
+eingespeist werden können → die Spread-Annahme greift dort nicht. Der
+Netz-Anteil bringt nur einen Vorteil, wenn der Ladepreis < Bezugspreis
+ist (klassisches Arbitrage-Setup). Stundengranulare Ladepreise und
+SoC-tolerante η-Bilanz folgen in Etappe C.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+# Mindest-Monate IST-Historie, ab der die Routes auf das gemessene
+# Aggregat statt der reinen Prognose umschalten. Unter dieser Schwelle ist
+# die Stichprobe zu klein für eine belastbare Hochrechnung auf das Jahr.
+SPEICHER_IST_MIN_MONATE: int = 3
+
+
+@dataclass
+class SpeicherIstAggregat:
+    """Aus IMD aggregierte Jahres-IST-Werte für einen Speicher.
+
+    Felder sind bereits auf das Jahr hochgerechnet — `jahres_faktor` ist
+    die genutzte Skalierung (12 / anzahl_monate) und dient nur der
+    Nachvollziehbarkeit im Detail-Dict / Diagnose.
+    """
+    entladung_kwh_jahr: float
+    ladung_netz_kwh_jahr: float
+    ladung_kwh_jahr: float
+    anzahl_monate: int
+    jahres_faktor: float
+
+
+def aggregiere_speicher_ist(
+    verbrauch_daten_je_monat: Iterable[dict],
+) -> Optional[SpeicherIstAggregat]:
+    """Aggregiert IST-Monatsdaten eines Speichers auf Jahreswerte.
+
+    Erwartet eine Iterable von `verbrauch_daten`-Dicts (typischerweise aus
+    `InvestitionMonatsdaten.verbrauch_daten`), die der Caller bereits auf
+    aktive Monate des Speichers gefiltert hat (`Investition.ist_aktiv_im_monat`).
+
+    Liefert `None`, wenn weniger als `SPEICHER_IST_MIN_MONATE` Monate
+    vorliegen oder gar keine Entladung erfasst ist — der Caller fällt
+    dann auf das Prognose-Modell zurück.
+    """
+    entladung_sum = 0.0
+    ladung_netz_sum = 0.0
+    ladung_sum = 0.0
+    monate = 0
+
+    for data in verbrauch_daten_je_monat:
+        if not data:
+            continue
+        monate += 1
+        entladung_sum += float(data.get("entladung_kwh") or 0)
+        # `ladung_netz_kwh` ist der Kanon (siehe field_definitions.LEGACY_FELDNAMEN);
+        # Legacy-Key `speicher_ladung_netz_kwh` als Fallback für historische Rows.
+        ladung_netz_sum += float(
+            data.get("ladung_netz_kwh") or data.get("speicher_ladung_netz_kwh") or 0
+        )
+        ladung_sum += float(data.get("ladung_kwh") or 0)
+
+    if monate < SPEICHER_IST_MIN_MONATE or entladung_sum <= 0:
+        return None
+
+    # Auf 12 Monate hochrechnen — bei weniger als 12 erfassten Monaten ist das
+    # eine konservative Annahme (Saison-Effekte werden geglättet). Bei ≥ 12
+    # ist `jahres_faktor` < 1 und kürzt fair auf einen Jahreswert.
+    jahres_faktor = 12.0 / monate
+
+    return SpeicherIstAggregat(
+        entladung_kwh_jahr=entladung_sum * jahres_faktor,
+        ladung_netz_kwh_jahr=ladung_netz_sum * jahres_faktor,
+        ladung_kwh_jahr=ladung_sum * jahres_faktor,
+        anzahl_monate=monate,
+        jahres_faktor=jahres_faktor,
+    )
 
 
 @dataclass
@@ -27,6 +100,13 @@ class SpeicherErsparnisErgebnis:
     """Ergebnis Speicher- oder V2H-Ersparnis-Berechnung."""
     ersparnis_euro: float
     spread_cent_kwh: float
+    # Aufgliederung der Ersparnis nach Energie-Quelle (Etappe B).
+    # Ohne Netzladung: pv_anteil_euro = ersparnis_euro, netz_anteil_euro = 0.
+    pv_anteil_euro: float = 0.0
+    netz_anteil_euro: float = 0.0
+    # kWh-Aufteilung der Entladung — für Frontend-KPI / Diagnose.
+    pv_anteil_entladung_kwh: float = 0.0
+    netz_anteil_entladung_kwh: float = 0.0
 
 
 def berechne_speicher_ersparnis(
@@ -34,22 +114,77 @@ def berechne_speicher_ersparnis(
     entladung_kwh: float,
     bezug_preis_cent: float,
     einspeise_verg_cent: float,
+    ladung_netz_kwh: float = 0.0,
+    wirkungsgrad_prozent: float = 95.0,
+    lade_preis_cent: Optional[float] = None,
 ) -> SpeicherErsparnisErgebnis:
-    """Spread-Ersparnis: Was hätte die gespeicherte Energie sonst gebracht?
+    """Spread-Ersparnis mit Netz-/PV-Aufteilung (Etappe B Issue #264).
+
+    Ohne Netzladung (`ladung_netz_kwh=0`) entspricht das Ergebnis exakt
+    dem alten Verhalten: Spread = entladung × (bezug − einspeise).
+
+    Bei gepflegter Netzladung wird die Entladung auf zwei Quellen aufgeteilt:
+
+      netz_anteil_entladung = min(entladung, ladung_netz × η)
+      pv_anteil_entladung   = entladung − netz_anteil_entladung
+
+    Der PV-Anteil bringt weiterhin den Spread (Energie hätte sonst eingespeist
+    werden können). Der Netz-Anteil bringt nur dann einen Vorteil, wenn ein
+    `lade_preis_cent` gepflegt ist und unter dem Bezugspreis liegt — sonst
+    ist die Netzladung kostenneutrale Durchleitung (z. B. Backup-Vorhaltung).
 
     Args:
         entladung_kwh: Aus Speicher entladene Energie in kWh
         bezug_preis_cent: Bezugspreis in ct/kWh (allgemeiner Tarif)
-        einspeise_verg_cent: Einspeisevergütung in ct/kWh (alternative Verwendung)
+        einspeise_verg_cent: Einspeisevergütung in ct/kWh
+        ladung_netz_kwh: Gepflegte Netzladung in kWh (Default 0 — reiner PV-Speicher)
+        wirkungsgrad_prozent: Speicher-Wirkungsgrad (Default 95 %)
+        lade_preis_cent: Ø-Ladepreis Netz in ct/kWh (None → Bezugspreis, kein Vorteil)
 
     Returns:
-        Ersparnis = entladung × (bezug − einspeise)
+        SpeicherErsparnisErgebnis mit pv_anteil_euro + netz_anteil_euro Aufschlüsselung.
     """
     if entladung_kwh <= 0:
         return SpeicherErsparnisErgebnis(0.0, 0.0)
+
     spread = max(0.0, bezug_preis_cent - einspeise_verg_cent)
-    ersparnis = entladung_kwh * spread / 100
-    return SpeicherErsparnisErgebnis(ersparnis_euro=ersparnis, spread_cent_kwh=spread)
+
+    # Backwards-kompat: ohne Netzladung-Datenpunkt verhält sich die Funktion
+    # genau wie vorher (PV-100%-Annahme, alleiniger Spread-Term).
+    if ladung_netz_kwh <= 0:
+        ersparnis = entladung_kwh * spread / 100
+        return SpeicherErsparnisErgebnis(
+            ersparnis_euro=ersparnis,
+            spread_cent_kwh=spread,
+            pv_anteil_euro=ersparnis,
+            netz_anteil_euro=0.0,
+            pv_anteil_entladung_kwh=entladung_kwh,
+            netz_anteil_entladung_kwh=0.0,
+        )
+
+    # Netz-Anteil der Entladung = eingebrachte Netz-Energie nach Wirkungsgrad,
+    # aber höchstens die tatsächlich entladene Menge (Clamp).
+    wirkungsgrad = max(0.0, min(1.0, wirkungsgrad_prozent / 100.0))
+    netz_anteil_entladung = min(entladung_kwh, ladung_netz_kwh * wirkungsgrad)
+    pv_anteil_entladung = max(0.0, entladung_kwh - netz_anteil_entladung)
+
+    # PV-Anteil: Spread wie bisher.
+    pv_ersparnis = pv_anteil_entladung * spread / 100
+
+    # Netz-Anteil: nur Vorteil, wenn Ladepreis < Bezugspreis (Arbitrage).
+    # Ohne gepflegten Ladepreis → kostenneutrale Annahme (Bezugspreis = Ladepreis).
+    ladepreis_eff = bezug_preis_cent if lade_preis_cent is None else lade_preis_cent
+    netz_spread = max(0.0, bezug_preis_cent - ladepreis_eff)
+    netz_ersparnis = netz_anteil_entladung * netz_spread / 100
+
+    return SpeicherErsparnisErgebnis(
+        ersparnis_euro=pv_ersparnis + netz_ersparnis,
+        spread_cent_kwh=spread,
+        pv_anteil_euro=pv_ersparnis,
+        netz_anteil_euro=netz_ersparnis,
+        pv_anteil_entladung_kwh=pv_anteil_entladung,
+        netz_anteil_entladung_kwh=netz_anteil_entladung,
+    )
 
 
 def berechne_v2h_ersparnis(

--- a/eedc/backend/tests/test_speicher_wirtschaftlichkeit_netzanteil.py
+++ b/eedc/backend/tests/test_speicher_wirtschaftlichkeit_netzanteil.py
@@ -1,0 +1,335 @@
+"""
+Akzeptanztest Etappe B (Issue #264): Spread-Modell mit PV/Netz-Anteil.
+
+Deckt drei Schichten ab:
+
+  1. `services.speicher_wirtschaftlichkeit.berechne_speicher_ersparnis`
+     mit der neuen `ladung_netz_kwh`-Signatur (Regression + Edge-Cases).
+  2. `services.speicher_wirtschaftlichkeit.aggregiere_speicher_ist`
+     (Jahres-Hochrechnung + Mindest-Monate-Schwelle).
+  3. `core.calculations.berechne_speicher_einsparung`-Wrapper:
+     - alte Signatur (Prognose) verhält sich identisch wie vor Etappe B
+     - neue Signatur (`ist_entladung_kwh` gepflegt) delegiert an den
+       Spread-Service und liefert identische Zahlen.
+
+Self-contained:
+
+    eedc/backend/venv/bin/python eedc/backend/tests/test_speicher_wirtschaftlichkeit_netzanteil.py
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+import traceback
+from pathlib import Path
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]  # eedc/
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+from backend.core.calculations import (  # noqa: E402
+    SPEICHER_ZYKLEN_PRO_JAHR,
+    berechne_speicher_einsparung,
+)
+from backend.services.speicher_wirtschaftlichkeit import (  # noqa: E402
+    SPEICHER_IST_MIN_MONATE,
+    aggregiere_speicher_ist,
+    berechne_speicher_ersparnis,
+)
+
+
+def _approx(a: float, b: float, tol: float = 0.01) -> bool:
+    return math.isclose(a, b, abs_tol=tol)
+
+
+# ----------------------------------------------------------------------------
+# berechne_speicher_ersparnis — Spread-Service
+# ----------------------------------------------------------------------------
+
+def test_reiner_pv_speicher_ohne_netzladung_regression() -> None:
+    # ladung_netz_kwh=0 → exakt das alte Verhalten (Spread × Entladung).
+    r = berechne_speicher_ersparnis(
+        entladung_kwh=500,
+        bezug_preis_cent=30,
+        einspeise_verg_cent=8,
+    )
+    # 500 kWh × (30 − 8) ct = 11000 ct = 110 €
+    assert _approx(r.ersparnis_euro, 110.0)
+    assert _approx(r.pv_anteil_euro, 110.0)
+    assert _approx(r.netz_anteil_euro, 0.0)
+    assert _approx(r.pv_anteil_entladung_kwh, 500.0)
+    assert _approx(r.netz_anteil_entladung_kwh, 0.0)
+
+
+def test_netzladung_ohne_ladepreis_kostet_keinen_pv_vorteil() -> None:
+    # 200 kWh Netzladung × η95 = 190 kWh netzgespeiste Entladung.
+    # PV-Anteil = 500 − 190 = 310 kWh × 22 ct = 68.20 €
+    # Netz-Anteil = 190 kWh × (30 − 30) = 0 € (kein Ladepreis → kostenneutral)
+    r = berechne_speicher_ersparnis(
+        entladung_kwh=500,
+        bezug_preis_cent=30,
+        einspeise_verg_cent=8,
+        ladung_netz_kwh=200,
+        wirkungsgrad_prozent=95,
+    )
+    assert _approx(r.netz_anteil_entladung_kwh, 190.0)
+    assert _approx(r.pv_anteil_entladung_kwh, 310.0)
+    assert _approx(r.pv_anteil_euro, 310 * 0.22)
+    assert _approx(r.netz_anteil_euro, 0.0)
+    assert _approx(r.ersparnis_euro, 310 * 0.22)
+
+
+def test_netzladung_mit_guenstigem_ladepreis_bringt_arbitrage() -> None:
+    # Wie oben, aber Ladepreis 12 ct → Netz-Spread 30−12 = 18 ct
+    # Netz-Anteil: 190 × 0.18 = 34.20 €
+    r = berechne_speicher_ersparnis(
+        entladung_kwh=500,
+        bezug_preis_cent=30,
+        einspeise_verg_cent=8,
+        ladung_netz_kwh=200,
+        wirkungsgrad_prozent=95,
+        lade_preis_cent=12,
+    )
+    assert _approx(r.netz_anteil_euro, 190 * 0.18)
+    assert _approx(r.pv_anteil_euro, 310 * 0.22)
+    assert _approx(r.ersparnis_euro, 310 * 0.22 + 190 * 0.18)
+
+
+def test_netzladung_groesser_als_entladung_geclamped() -> None:
+    # Wenn jemand mehr Netzladung erfasst als Entladung (z. B. Speicher füllt
+    # sich im Monat, Energie wird ins nächste verschoben), darf der Netz-Anteil
+    # nicht > Entladung sein. Etappe C handhabt das sauber über SoC-Bilanz,
+    # Etappe B clamped pragmatisch.
+    r = berechne_speicher_ersparnis(
+        entladung_kwh=100,
+        bezug_preis_cent=30,
+        einspeise_verg_cent=8,
+        ladung_netz_kwh=500,  # × 0.95 = 475 → clamped auf 100
+        wirkungsgrad_prozent=95,
+        lade_preis_cent=12,
+    )
+    assert _approx(r.netz_anteil_entladung_kwh, 100.0)
+    assert _approx(r.pv_anteil_entladung_kwh, 0.0)
+    assert _approx(r.netz_anteil_euro, 100 * 0.18)
+    assert _approx(r.pv_anteil_euro, 0.0)
+
+
+def test_bezug_unter_einspeisung_clampt_spread_auf_null() -> None:
+    # Edge: degenerierte Tarif-Konstellation (Bezug < Einspeisung) ergibt
+    # keinen Speicher-Vorteil — Verhalten existiert bereits, hier nur Regression.
+    r = berechne_speicher_ersparnis(
+        entladung_kwh=300,
+        bezug_preis_cent=5,
+        einspeise_verg_cent=10,
+    )
+    assert _approx(r.ersparnis_euro, 0.0)
+
+
+def test_keine_entladung_keine_ersparnis() -> None:
+    r = berechne_speicher_ersparnis(
+        entladung_kwh=0,
+        bezug_preis_cent=30,
+        einspeise_verg_cent=8,
+        ladung_netz_kwh=100,
+        lade_preis_cent=10,
+    )
+    assert _approx(r.ersparnis_euro, 0.0)
+
+
+# ----------------------------------------------------------------------------
+# aggregiere_speicher_ist
+# ----------------------------------------------------------------------------
+
+def test_aggregiere_speicher_ist_hochrechnung_auf_jahr() -> None:
+    # 6 Monate à 100/80 kWh + 50 kWh Netz → Jahres-Hochrechnung × 2
+    daten = [
+        {"ladung_kwh": 100, "entladung_kwh": 80, "ladung_netz_kwh": 50}
+        for _ in range(6)
+    ]
+    agg = aggregiere_speicher_ist(daten)
+    assert agg is not None
+    assert _approx(agg.entladung_kwh_jahr, 80 * 6 * 2)
+    assert _approx(agg.ladung_netz_kwh_jahr, 50 * 6 * 2)
+    assert _approx(agg.ladung_kwh_jahr, 100 * 6 * 2)
+    assert agg.anzahl_monate == 6
+    assert _approx(agg.jahres_faktor, 2.0)
+
+
+def test_aggregiere_speicher_ist_zu_wenig_monate_gibt_none() -> None:
+    # SPEICHER_IST_MIN_MONATE = 3; mit 2 Monaten muss None zurückkommen.
+    assert SPEICHER_IST_MIN_MONATE == 3  # contract test
+    daten = [{"ladung_kwh": 100, "entladung_kwh": 80}] * 2
+    assert aggregiere_speicher_ist(daten) is None
+
+
+def test_aggregiere_speicher_ist_ohne_entladung_gibt_none() -> None:
+    daten = [{"ladung_kwh": 100, "entladung_kwh": 0}] * 6
+    assert aggregiere_speicher_ist(daten) is None
+
+
+def test_aggregiere_speicher_ist_legacy_key_fallback() -> None:
+    # Historische Rows haben `speicher_ladung_netz_kwh` statt `ladung_netz_kwh`.
+    daten = [
+        {"ladung_kwh": 100, "entladung_kwh": 80, "speicher_ladung_netz_kwh": 25}
+        for _ in range(12)
+    ]
+    agg = aggregiere_speicher_ist(daten)
+    assert agg is not None
+    assert _approx(agg.ladung_netz_kwh_jahr, 25 * 12)
+
+
+# ----------------------------------------------------------------------------
+# berechne_speicher_einsparung — Wrapper (calculations.py)
+# ----------------------------------------------------------------------------
+
+def test_wrapper_prognose_modus_unveraendert_ohne_arbitrage() -> None:
+    # Kein ist_entladung_kwh → alter Prognose-Pfad. Erwartete Werte ergeben
+    # sich aus: Kapazität × Zyklen × η × (Bezug − Einspeise).
+    r = berechne_speicher_einsparung(
+        kapazitaet_kwh=10,
+        wirkungsgrad_prozent=95,
+        netzbezug_preis_cent=30,
+        einspeiseverguetung_cent=8,
+        nutzt_arbitrage=False,
+    )
+    nutzbar = 10 * SPEICHER_ZYKLEN_PRO_JAHR * 0.95
+    erwartet = nutzbar * 0.22
+    assert _approx(r.jahres_einsparung_euro, round(erwartet, 2))
+    assert _approx(r.pv_anteil_euro, round(erwartet, 2))
+    assert r.arbitrage_anteil_euro == 0
+
+
+def test_wrapper_prognose_modus_unveraendert_mit_arbitrage_70_30() -> None:
+    # 70/30-Modell mit Param-Preisen — alte Logik bleibt erhalten.
+    r = berechne_speicher_einsparung(
+        kapazitaet_kwh=10,
+        wirkungsgrad_prozent=95,
+        netzbezug_preis_cent=30,
+        einspeiseverguetung_cent=8,
+        nutzt_arbitrage=True,
+        lade_preis_cent=12,
+        entlade_preis_cent=35,
+    )
+    nutzbar = 10 * SPEICHER_ZYKLEN_PRO_JAHR * 0.95
+    erwartet_pv = nutzbar * 0.70 * 0.22
+    erwartet_arb = nutzbar * 0.30 * 0.23
+    assert _approx(r.jahres_einsparung_euro, round(erwartet_pv + erwartet_arb, 2))
+
+
+def test_wrapper_ist_modus_delegiert_an_spread_service() -> None:
+    # ist_entladung_kwh gepflegt + Netzladung → Delegation an den
+    # Spread-Service. Werte müssen mit direktem Service-Aufruf übereinstimmen.
+    spread = berechne_speicher_ersparnis(
+        entladung_kwh=2000,
+        bezug_preis_cent=30,
+        einspeise_verg_cent=8,
+        ladung_netz_kwh=400,
+        wirkungsgrad_prozent=95,
+        lade_preis_cent=None,  # nutzt_arbitrage=False → kein Lade-Preis-Bonus
+    )
+    wrapper = berechne_speicher_einsparung(
+        kapazitaet_kwh=10,
+        wirkungsgrad_prozent=95,
+        netzbezug_preis_cent=30,
+        einspeiseverguetung_cent=8,
+        nutzt_arbitrage=False,
+        ist_entladung_kwh=2000,
+        ist_ladung_netz_kwh=400,
+    )
+    assert _approx(wrapper.jahres_einsparung_euro, round(spread.ersparnis_euro, 2))
+    assert _approx(wrapper.pv_anteil_euro, round(spread.pv_anteil_euro, 2))
+    assert _approx(wrapper.arbitrage_anteil_euro, round(spread.netz_anteil_euro, 2))
+    assert _approx(wrapper.nutzbare_speicherung_kwh, 2000.0)
+
+
+def test_wrapper_ist_modus_mit_arbitrage_nimmt_lade_preis_mit() -> None:
+    spread = berechne_speicher_ersparnis(
+        entladung_kwh=2000,
+        bezug_preis_cent=30,
+        einspeise_verg_cent=8,
+        ladung_netz_kwh=400,
+        wirkungsgrad_prozent=95,
+        lade_preis_cent=12,
+    )
+    wrapper = berechne_speicher_einsparung(
+        kapazitaet_kwh=10,
+        wirkungsgrad_prozent=95,
+        netzbezug_preis_cent=30,
+        einspeiseverguetung_cent=8,
+        nutzt_arbitrage=True,
+        lade_preis_cent=12,
+        entlade_preis_cent=35,  # im IST-Modus irrelevant
+        ist_entladung_kwh=2000,
+        ist_ladung_netz_kwh=400,
+    )
+    assert _approx(wrapper.jahres_einsparung_euro, round(spread.ersparnis_euro, 2))
+    assert wrapper.arbitrage_anteil_euro > 0  # Netz-Anteil-Vorteil sichtbar
+
+
+def test_wrapper_ist_modus_co2_basiert_auf_pv_anteil() -> None:
+    # CO2-Vorteil bezieht sich auf den PV-Anteil — der Netz-Anteil
+    # ersetzt zwar Bezugskosten, aber nicht den Strommix.
+    wrapper = berechne_speicher_einsparung(
+        kapazitaet_kwh=10,
+        wirkungsgrad_prozent=95,
+        netzbezug_preis_cent=30,
+        einspeiseverguetung_cent=8,
+        ist_entladung_kwh=1000,
+        ist_ladung_netz_kwh=0,
+    )
+    # Reiner PV: 1000 kWh × 0.38 = 380 kg
+    assert _approx(wrapper.co2_einsparung_kg, 380.0)
+
+    wrapper_mit_netz = berechne_speicher_einsparung(
+        kapazitaet_kwh=10,
+        wirkungsgrad_prozent=95,
+        netzbezug_preis_cent=30,
+        einspeiseverguetung_cent=8,
+        ist_entladung_kwh=1000,
+        ist_ladung_netz_kwh=500,  # × 0.95 = 475 → 525 PV-Anteil
+    )
+    assert _approx(wrapper_mit_netz.co2_einsparung_kg, round(525 * 0.38, 1))
+
+
+# ----------------------------------------------------------------------------
+# Runner
+# ----------------------------------------------------------------------------
+
+ALLE_TESTS = [
+    test_reiner_pv_speicher_ohne_netzladung_regression,
+    test_netzladung_ohne_ladepreis_kostet_keinen_pv_vorteil,
+    test_netzladung_mit_guenstigem_ladepreis_bringt_arbitrage,
+    test_netzladung_groesser_als_entladung_geclamped,
+    test_bezug_unter_einspeisung_clampt_spread_auf_null,
+    test_keine_entladung_keine_ersparnis,
+    test_aggregiere_speicher_ist_hochrechnung_auf_jahr,
+    test_aggregiere_speicher_ist_zu_wenig_monate_gibt_none,
+    test_aggregiere_speicher_ist_ohne_entladung_gibt_none,
+    test_aggregiere_speicher_ist_legacy_key_fallback,
+    test_wrapper_prognose_modus_unveraendert_ohne_arbitrage,
+    test_wrapper_prognose_modus_unveraendert_mit_arbitrage_70_30,
+    test_wrapper_ist_modus_delegiert_an_spread_service,
+    test_wrapper_ist_modus_mit_arbitrage_nimmt_lade_preis_mit,
+    test_wrapper_ist_modus_co2_basiert_auf_pv_anteil,
+]
+
+
+def main() -> int:
+    fehler = 0
+    for fn in ALLE_TESTS:
+        try:
+            fn()
+            print(f"PASS  {fn.__name__}")
+        except Exception:  # noqa: BLE001
+            fehler += 1
+            print(f"FAIL  {fn.__name__}")
+            traceback.print_exc()
+    if fehler:
+        print(f"\n{fehler} Tests fehlgeschlagen.")
+        return 1
+    print(f"\nAlle {len(ALLE_TESTS)} Tests grün.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Etappe B der drei-stufigen Umsetzung aus #264. Folgt unabhängig auf [#269 (Etappe A — Erfassungs-Schalter)](https://github.com/supernova1963/eedc-homeassistant/pull/269) — Etappe A und B können in beliebiger Reihenfolge gemergt werden.

## Was diese Etappe liefert

Der Spread-Service unterstützt jetzt eine **gemessene Netzladung** und trennt PV- und Netz-Anteil der Speicher-Entladung. Bisher wurde implizit 100 % PV-Ladung unterstellt — bei netz-mitgespeisten Speichern hat das die Wirtschaftlichkeit überschätzt.

## Berechnungs-Logik

```text
netz_anteil_entladung = min(entladung, ladung_netz × η)
pv_anteil_entladung   = entladung − netz_anteil_entladung

# PV-Anteil: hätte sonst eingespeist werden können → Spread wie bisher
pv_ersparnis  = pv_anteil_entladung × (bezug − einspeise)

# Netz-Anteil: nur Vorteil, wenn Ladepreis < Bezugspreis (Arbitrage)
netz_ersparnis = max(0, netz_anteil_entladung × (bezug − ladepreis))
```

Ohne `ladung_netz_kwh` (Default 0) verhält sich der Service exakt wie vorher — **Backwards-kompatibel**. Ohne gepflegten `lade_preis_cent` bringt die Netzladung null Vorteil (kostenneutrale Backup-Ladung) — konservativer als ein erfundener Mittelwert.

## Drift-Audit D — gemeinsamer Helper

`core.calculations.berechne_speicher_einsparung()` wird im IST-Pfad zum dünnen Wrapper um `services.speicher_wirtschaftlichkeit.berechne_speicher_ersparnis()`. Damit nutzen Aussichten und Investitionen-ROI im IST-Pfad denselben kanonischen Helper — beide können nicht mehr auseinanderdriften, ohne dass die Routes selbst konsolidiert werden mussten. Der Prognose-Pfad (kein IST-Wert) bleibt unverändert (Zyklen × Kapazität × η).

## Änderungen

| Datei | Änderung |
| --- | --- |
| `services/speicher_wirtschaftlichkeit.py` | Spread-Service-Signatur erweitert + Ergebnis-Dataclass (`pv_anteil_euro`, `netz_anteil_euro`, `pv_anteil_entladung_kwh`, `netz_anteil_entladung_kwh`). Neuer Helper `aggregiere_speicher_ist()` für IMD → Jahres-Hochrechnung (Schwelle ≥ 3 Monate, sonst Fallback auf Prognose). |
| `core/calculations.py` | `berechne_speicher_einsparung()` mit optionalen `ist_entladung_kwh` / `ist_ladung_netz_kwh`. Delegiert bei IST-Daten an Spread-Service; CO2-Vorteil basiert auf PV-Anteil (Netzladung spart keinen Strommix). |
| `api/routes/investitionen.py` | Speicher-IMDs einmalig vor Phase 3 laden, pro Speicher aggregieren (Stilllegungsfilter analog #236), an beide ROI-Pfade (DC + AC) durchreichen. Detail-Dict um `modus` (`ist`/`prognose`), `pv_anteil_euro`, `netz_anteil_euro`, `ist_entladung_kwh_jahr`, `ist_ladung_netz_kwh_jahr`, `ist_monate` erweitert. |
| `api/routes/aussichten.py` | Historische Speicher-Ladung → `netz_anteil_lade` ableiten, auf prognostizierten Speicher-Beitrag projizieren. Ladepreis aus Param-Mittelwert der arbitragefähigen Speicher (None wenn keiner arbitragefähig). |
| `tests/test_speicher_wirtschaftlichkeit_netzanteil.py` (neu) | 15 Test-Cases (Spread-Service, Aggregations-Helper, Wrapper-Delegation, Regression). |

## Was nicht in B steckt (kommt C)

- **Stundengranulare Ladepreis-Rekonstruktion** aus `TagesEnergieProfil` — für Tibber/aWATTar-Setups, sodass der echte Mittel-Ladepreis aus den HA-LTS-Stundenwerten kommt, ohne dass der User den Param-Ø pflegen muss. In B sieht ein Nicht-Arbitrage-Speicher 0 € Netz-Vorteil (konservativ); C liefert den realistischen Wert.
- **IST-η mit SoC-Korrektur** über die Monatsgrenze — gegen den 110 %-Effekt bei Voll-zu-Leer-Übergängen (siehe #264 SoC-Drift).
- **Frontend-KPI-Tiles** für Netz-Anteil + effektiver Ladepreis.

## Tests

```text
backend/venv/bin/python backend/tests/test_speicher_wirtschaftlichkeit_netzanteil.py
PASS  test_reiner_pv_speicher_ohne_netzladung_regression
PASS  test_netzladung_ohne_ladepreis_kostet_keinen_pv_vorteil
PASS  test_netzladung_mit_guenstigem_ladepreis_bringt_arbitrage
PASS  test_netzladung_groesser_als_entladung_geclamped
PASS  test_bezug_unter_einspeisung_clampt_spread_auf_null
PASS  test_keine_entladung_keine_ersparnis
PASS  test_aggregiere_speicher_ist_hochrechnung_auf_jahr
PASS  test_aggregiere_speicher_ist_zu_wenig_monate_gibt_none
PASS  test_aggregiere_speicher_ist_ohne_entladung_gibt_none
PASS  test_aggregiere_speicher_ist_legacy_key_fallback
PASS  test_wrapper_prognose_modus_unveraendert_ohne_arbitrage
PASS  test_wrapper_prognose_modus_unveraendert_mit_arbitrage_70_30
PASS  test_wrapper_ist_modus_delegiert_an_spread_service
PASS  test_wrapper_ist_modus_mit_arbitrage_nimmt_lade_preis_mit
PASS  test_wrapper_ist_modus_co2_basiert_auf_pv_anteil
Alle 15 Tests grün.
```

Regression auf bestehende Speicher-/Import-Tests grün: `test_custom_import_preview_inv_werte` (5/5), `test_emob_pool_komponenten` (4/4), `test_inv_value_spalten_fallback` (6/6).

## Verhalten

| Speicher-Setup | Ergebnis IST-Modus | Ergebnis Prognose-Modus |
| --- | --- | --- |
| Reiner PV (`ladung_netz_kwh=0`) | identisch zu vorher | identisch zu vorher |
| Netzladung erfasst, kein Arbitrage-Param | Netz-Anteil 0 €, PV-Anteil korrekt reduziert | Prognose unverändert |
| Netzladung erfasst, Arbitrage-Param (Ladepreis < Bezug) | Netz-Anteil als positiver Arbitrage-Gewinn ausgewiesen | Prognose unverändert |

## Test plan

- [ ] Backend-Tests grün: `python eedc/backend/tests/test_speicher_wirtschaftlichkeit_netzanteil.py`
- [ ] Regression Speicher-/Import-Tests grün
- [ ] API-Smoke: ROI-Endpoint zeigt `modus`, `pv_anteil_euro`, `netz_anteil_euro` im Detail-Dict
- [ ] API-Smoke: Aussichten-Endpoint nutzt historischen `netz_anteil_lade` für Speicher-Komponentenbeitrag
- [ ] Regression: Anlage ohne `ladung_netz_kwh`-Werte liefert exakt dieselben Zahlen wie vor dem Patch

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)