### PR TITLE
fix(gitignore): SQLite WAL+SHM-Backup-Begleitdateien ignorieren

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,10 @@ logs/
 .coverage
 htmlcov/
 .claude/
+
+# SQLite Backup-Begleitdateien (WAL + Shared-Memory) — entstehen während
+# des HA-Backup-WAL-Checkpoint-Hooks (#266) parallel zur .bak-Datei und
+# enthalten flüchtige Transaktionsdaten. Pattern ist bewusst breit, damit
+# zusätzliche Backup-Targets oder Test-Snapshots automatisch mit greifen.
+eedc/data/*-wal
+eedc/data/*-shm


### PR DESCRIPTION
Folge zu #266 (HA-Backup-Konsistenz via WAL-Checkpoint pre-Backup-Hook).

## Was und warum

Beim WAL-Checkpoint-Backup entstehen neben der `.bak`-Datei zwei flüchtige Begleitdateien:

- `*-wal`: Write-Ahead-Log mit nicht-committed-Transaktionen
- `*-shm`: Shared-Memory-Region zwischen Writern

Bei aktiver Sitzung lagen die bisher unignoriert im Working-Tree und tauchten in jedem `git status` auf. Sie gehören nicht ins Repo.

## Wahl des Patterns

Bewusst breit (`eedc/data/*-wal`, `eedc/data/*-shm`) statt fest auf `eedc.db.bak-{shm,wal}` — damit zusätzliche Backup-Targets, Snapshot-Files oder Test-DBs in `eedc/data/` automatisch mit greifen.

## Verifikation

```
git check-ignore -v eedc/data/eedc.db.bak-shm eedc/data/eedc.db.bak-wal
.gitignore:62:eedc/data/*-shm	eedc/data/eedc.db.bak-shm
.gitignore:61:eedc/data/*-wal	eedc/data/eedc.db.bak-wal
```

## Aufräum-Hinweis (separat, nicht Teil dieses PRs)

`eedc/data/eedc.db.bak` selbst (~34 MB Backup-DB) ist als tracked file im Repo (`git ls-files eedc/data/`) und wird durch `.gitignore` nicht berührt, weil git nichts nachträglich ignoriert was bereits tracked ist. Falls das Backup-File aus dem Repo entfernt werden soll, wäre ein separater Commit mit `git rm --cached eedc/data/eedc.db.bak` + Pattern `eedc/data/*.bak` notwendig — bewusst nicht Teil dieses fokussierten Fixes.

## Test plan

- [ ] `git status` zeigt nach lokalem Backup-Lauf keine `-wal`/`-shm`-Files mehr als untracked
- [ ] `git check-ignore -v eedc/data/foo-wal` matched das neue Pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)