### PR TITLE
fix(cockpit): Spez. Ertrag bei 'alle Jahre' & historischen Größenänderungen

### DIFF
--- a/eedc/backend/api/routes/cockpit/uebersicht.py
+++ b/eedc/backend/api/routes/cockpit/uebersicht.py
@@ -339,9 +339,26 @@ async def get_cockpit_uebersicht(
     # des Jahresertrags, nicht 42%. Daher Periodenanteil über die
     # PVGIS-Monatsverteilung gewichten; Fallback auf typische 52°N-Verteilung
     # bzw. Gleichverteilung wenn keine PVGIS-Prognose vorliegt.
-    covered_months: set[tuple[int, int]] = set(zeitraum_monate)
-    for md in monatsdaten_list:
-        covered_months.add((md.jahr, md.monat))
+    #
+    # WICHTIG (Folge-Bug "alle Jahre"): covered_months darf NUR Monate
+    # enthalten, in denen tatsächlich eine PV-/BKW-Investition aktiv war.
+    # Sonst rutschen WP-/Speicher-/Zähler-Monate aus der Zeit vor PV-Inbetrieb-
+    # nahme rein, periode_anteil wird zu groß und spez_ertrag zu klein
+    # (Symptom: ~300 kWh/kWp bei "alle Jahre").
+    covered_months: set[tuple[int, int]] = set()
+    for imd in all_imd:
+        inv = inv_by_id.get(imd.investition_id)
+        if not inv or inv.typ not in ("pv-module", "balkonkraftwerk"):
+            continue
+        if not inv.ist_aktiv_im_monat(imd.jahr, imd.monat):
+            continue
+        covered_months.add((imd.jahr, imd.monat))
+    # Fallback für Setups ohne PV-IMDs (nur Anlagen-Zähler):
+    # Monate mit pv_erzeugung > 0 aus Monatsdaten heranziehen.
+    if not covered_months:
+        for md in monatsdaten_list:
+            if (md.pv_erzeugung_kwh or 0) > 0:
+                covered_months.add((md.jahr, md.monat))
 
     monthly_weight: dict[int, float] = {}
     if covered_months and anlagenleistung_kwp > 0:
@@ -368,19 +385,44 @@ async def get_cockpit_uebersicht(
                 7: 13.5, 8: 12.0, 9: 9.0, 10: 6.5, 11: 3.5, 12: 2.5,
             }
 
-    periode_anteil: Optional[float] = None
-    weight_sum_year = sum(monthly_weight.values())
-    if covered_months and weight_sum_year > 0:
-        months_per_year: dict[int, set[int]] = {}
-        for (j, m) in covered_months:
-            months_per_year.setdefault(j, set()).add(m)
-        anteil = 0.0
-        for monate_set in months_per_year.values():
-            anteil += sum(monthly_weight.get(m, 0.0) for m in monate_set) / weight_sum_year
-        periode_anteil = anteil if anteil > 0 else None
+    # Nenner pro Monat mit der TATSÄCHLICH AKTIVEN PV-Leistung gewichten.
+    # Bug-Symptom "alle Jahre = ~300 kWh/kWp": Anlagen, die über die Jahre
+    # erweitert wurden, hatten den heutigen kWp-Stand × Jahresanzahl als
+    # Nenner. Frühere Jahre mit kleinerer Anlage wurden so künstlich
+    # niedrig gerechnet. Per-Monat-Lookup via ist_aktiv_im_monat liefert
+    # die historisch korrekte Leistung pro Datenpunkt.
+    def _kwp_aktiv_im_monat(jahr: int, monat: int) -> float:
+        kwp = 0.0
+        for inv in investitionen:
+            if inv.typ not in ("pv-module", "balkonkraftwerk"):
+                continue
+            if not inv.ist_aktiv_im_monat(jahr, monat):
+                continue
+            if inv.typ == "pv-module" and inv.leistung_kwp:
+                kwp += inv.leistung_kwp
+            elif inv.typ == "balkonkraftwerk":
+                if inv.leistung_kwp:
+                    kwp += inv.leistung_kwp
+                else:
+                    params = inv.parameter or {}
+                    bkw_anzahl = params.get("anzahl", 1) or 1
+                    kwp += (params.get("leistung_wp", 0) or 0) * bkw_anzahl / 1000
+        return kwp
 
-    if anlagenleistung_kwp > 0 and periode_anteil and pv_erzeugung > 0:
-        spez_ertrag = pv_erzeugung / (anlagenleistung_kwp * periode_anteil)
+    weight_sum_year = sum(monthly_weight.values())
+    denom_kwp_jahre = 0.0  # Summe kWp·Jahres-Äquivalente
+    if covered_months and weight_sum_year > 0:
+        for (j, m) in covered_months:
+            w = monthly_weight.get(m, 0.0) / weight_sum_year
+            kwp_m = _kwp_aktiv_im_monat(j, m)
+            if kwp_m <= 0:
+                # Fallback wenn Investitionen ohne Anschaffungsdatum existieren
+                # oder Setup nur Anlagen-Zähler nutzt.
+                kwp_m = anlagenleistung_kwp
+            denom_kwp_jahre += kwp_m * w
+
+    if denom_kwp_jahre > 0 and pv_erzeugung > 0:
+        spez_ertrag = pv_erzeugung / denom_kwp_jahre
     elif anlagenleistung_kwp > 0:
         spez_ertrag = pv_erzeugung / anlagenleistung_kwp if pv_erzeugung > 0 else None
     else:

--- a/eedc/backend/tests/test_cockpit_spez_ertrag_periode.py
+++ b/eedc/backend/tests/test_cockpit_spez_ertrag_periode.py
@@ -199,6 +199,196 @@ async def test_fallback_ohne_pvgis_nutzt_52n_verteilung():
         )
 
 
+async def test_alle_jahre_mit_anlagen_erweiterung():
+    """Regression: Anlage über die Jahre erweitert. Bei „alle Jahre" darf
+    der Nenner nicht den heutigen kWp-Stand × Jahresanzahl nutzen, sondern
+    muss die pro Monat tatsächlich aktive PV-Leistung verwenden.
+
+    Szenario: 3 kWp seit 2020, +6 kWp seit 2023 (heute 9 kWp).
+    Jeder Modul-Anteil produziert sauber 1000 kWh/kWp/Jahr.
+      - A (3 kWp): 6 Jahre × 3000 kWh = 18000 kWh
+      - B (6 kWp): 3 Jahre × 6000 kWh = 18000 kWh
+      - Σ = 36000 kWh
+    Korrekt: 3 kWp·3 Jahre + 9 kWp·3 Jahre = 36 kWp·Jahre → 1000 kWh/kWp.
+    Buggy (heutige 9 kWp × 6 Jahre = 54): nur ~667 kWh/kWp.
+    """
+    from backend.api.routes.cockpit.uebersicht import get_cockpit_uebersicht
+
+    async with _session_ctx() as session:
+        anlage = Anlage(
+            anlagenname="ErweiterungsAnlage", leistung_kwp=9.0,
+            latitude=52.0, longitude=10.0,
+        )
+        session.add(anlage)
+        await session.flush()
+
+        pv_a = Investition(
+            anlage_id=anlage.id, typ="pv-module", bezeichnung="PV A",
+            leistung_kwp=3.0, anschaffungsdatum=date(2020, 1, 1),
+        )
+        pv_b = Investition(
+            anlage_id=anlage.id, typ="pv-module", bezeichnung="PV B",
+            leistung_kwp=6.0, anschaffungsdatum=date(2023, 1, 1),
+        )
+        session.add_all([pv_a, pv_b])
+        await session.flush()
+
+        # PVGIS-Prognose (Jahresertrag/kWp ist hier irrelevant, nur Verteilung)
+        _add_pvgis_prognose(session, anlage.id)
+
+        # A: 2020–2025 (6 Jahre × 3000 kWh)
+        for jahr in range(2020, 2026):
+            for m in range(1, 13):
+                kwh = 3000.0 * (SEASON_52N[m] / 100.0)
+                _add_imd(session, pv_a.id, jahr, m, kwh)
+        # B: 2023–2025 (3 Jahre × 6000 kWh)
+        for jahr in range(2023, 2026):
+            for m in range(1, 13):
+                kwh = 6000.0 * (SEASON_52N[m] / 100.0)
+                _add_imd(session, pv_b.id, jahr, m, kwh)
+        await session.commit()
+
+        resp = await get_cockpit_uebersicht(anlage_id=anlage.id, jahr=None, db=session)
+
+        # Sanity-Check Eingangsdaten
+        assert abs(resp.pv_erzeugung_kwh - 36000.0) < 1.0, (
+            f"Test-Setup defekt: pv_erzeugung sollte 36000 sein, war {resp.pv_erzeugung_kwh}"
+        )
+        assert resp.spezifischer_ertrag_kwh_kwp is not None
+        assert abs(resp.spezifischer_ertrag_kwh_kwp - 1000.0) < 5.0, (
+            f"Anlagen-Erweiterung: spez_ertrag muss 1000 kWh/kWp sein "
+            f"(per-Monat-aktives kWp), war {resp.spezifischer_ertrag_kwh_kwp}. "
+            f"Bug-Wert wäre ~667."
+        )
+
+
+async def test_alle_jahre_ignoriert_vor_pv_monate():
+    """Regression: bei jahr=None (alle Jahre) darf periode_anteil nicht aus
+    WP-/Zähler-Monaten vor PV-Inbetriebnahme aufgebläht werden.
+
+    Szenario: PV seit 2024 (2 volle Jahre 2024+2025), WP-IMDs seit 2020 (4
+    weitere Jahre nur WP), Stromzähler-Monatsdaten seit 2018 (6 weitere
+    Jahre). Bug-Symptom war: covered_months umfasste 2018–2025 → periode
+    ≈ 8, spez_ertrag = total_pv / (kWp × 8) statt × 2.
+    """
+    from backend.api.routes.cockpit.uebersicht import get_cockpit_uebersicht
+
+    async with _session_ctx() as session:
+        anlage, pv = await _setup_anlage_5kwp(session)
+        # PV-Anschaffung explizit 2024 setzen (überschreibt _setup-Default)
+        pv.anschaffungsdatum = date(2024, 1, 1)
+
+        # WP seit 2020 — IMDs vor PV-Zeit
+        wp = Investition(
+            anlage_id=anlage.id, typ="waermepumpe",
+            bezeichnung="WP", anschaffungsdatum=date(2020, 1, 1),
+        )
+        session.add(wp)
+        await session.flush()
+
+        _add_pvgis_prognose(session, anlage.id)
+
+        # WP-IMDs für 2020–2023 (vor PV) — dürfen periode_anteil NICHT aufblähen
+        for jahr in (2020, 2021, 2022, 2023):
+            for m in range(1, 13):
+                session.add(InvestitionMonatsdaten(
+                    investition_id=wp.id, jahr=jahr, monat=m,
+                    verbrauch_daten={"stromverbrauch_kwh": 100.0, "heizenergie_kwh": 400.0},
+                ))
+
+        # Zähler-Monatsdaten ab 2018 (noch früher) — dürfen ebenfalls nicht zählen
+        for jahr in (2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025):
+            for m in range(1, 13):
+                session.add(Monatsdaten(
+                    anlage_id=anlage.id, jahr=jahr, monat=m,
+                    netzbezug_kwh=200.0, einspeisung_kwh=50.0,
+                ))
+
+        # PV-IMDs für 2 volle Jahre 2024+2025 (gemäß 52°N-Verteilung)
+        for jahr in (2024, 2025):
+            for m in range(1, 13):
+                kwh = 5000.0 * (SEASON_52N[m] / 100.0)
+                _add_imd(session, pv.id, jahr, m, kwh)
+        await session.commit()
+
+        resp = await get_cockpit_uebersicht(anlage_id=anlage.id, jahr=None, db=session)
+
+        # 2 PV-Jahre × 5000 kWh / (5 kWp × 2) = 1000 kWh/kWp.
+        # Buggy-Verhalten lieferte ~250 (Faktor ~4 zu niedrig).
+        assert resp.spezifischer_ertrag_kwh_kwp is not None
+        assert abs(resp.spezifischer_ertrag_kwh_kwp - 1000.0) < 5.0, (
+            f"'Alle Jahre' muss 1000 kWh/kWp ergeben (2 volle PV-Jahre), "
+            f"war {resp.spezifischer_ertrag_kwh_kwp}"
+        )
+
+
+async def test_alle_jahre_mit_teil_stilllegung():
+    """Regression: Anlage wird über die Jahre verkleinert (Teil-Rückbau).
+    Bei „alle Jahre" muss der Nenner pro Monat die DAMALS aktive Leistung
+    nutzen — sonst wird in den frühen Jahren mit der heute noch
+    verbleibenden Restleistung gerechnet und der Wert ist zu hoch.
+
+    Szenario: 10 kWp seit 2020. Anfang 2023 wird ein 4-kWp-Modul
+    stillgelegt → ab 2023 nur noch 6 kWp aktiv.
+      - A (6 kWp, durchgehend): 6 Jahre × 6000 kWh = 36000 kWh
+      - B (4 kWp, 2020–2022):   3 Jahre × 4000 kWh = 12000 kWh
+      - Σ pv_erzeugung = 48000 kWh
+    Korrekt: 6 kWp·6 Jahre + 4 kWp·3 Jahre = 48 kWp·Jahre → 1000 kWh/kWp.
+    Buggy (heutige 6 kWp × 6 Jahre = 36): 48000/36 ≈ 1333 (zu hoch).
+    """
+    from backend.api.routes.cockpit.uebersicht import get_cockpit_uebersicht
+
+    async with _session_ctx() as session:
+        anlage = Anlage(
+            anlagenname="StilllegungsAnlage", leistung_kwp=6.0,
+            latitude=52.0, longitude=10.0,
+        )
+        session.add(anlage)
+        await session.flush()
+
+        pv_a = Investition(
+            anlage_id=anlage.id, typ="pv-module", bezeichnung="PV A (Bestand)",
+            leistung_kwp=6.0, anschaffungsdatum=date(2020, 1, 1),
+        )
+        pv_b = Investition(
+            anlage_id=anlage.id, typ="pv-module", bezeichnung="PV B (rückgebaut)",
+            leistung_kwp=4.0,
+            anschaffungsdatum=date(2020, 1, 1),
+            stilllegungsdatum=date(2022, 12, 31),
+        )
+        session.add_all([pv_a, pv_b])
+        await session.flush()
+
+        _add_pvgis_prognose(session, anlage.id)
+
+        # A: 2020–2025 (6 Jahre × 6000 kWh)
+        for jahr in range(2020, 2026):
+            for m in range(1, 13):
+                _add_imd(session, pv_a.id, jahr, m, 6000.0 * (SEASON_52N[m] / 100.0))
+        # B: 2020–2022 (3 Jahre × 4000 kWh) — stillgelegt Ende 2022
+        for jahr in range(2020, 2023):
+            for m in range(1, 13):
+                _add_imd(session, pv_b.id, jahr, m, 4000.0 * (SEASON_52N[m] / 100.0))
+        await session.commit()
+
+        resp = await get_cockpit_uebersicht(anlage_id=anlage.id, jahr=None, db=session)
+
+        assert abs(resp.pv_erzeugung_kwh - 48000.0) < 1.0, (
+            f"Test-Setup defekt: pv_erzeugung sollte 48000 sein, war {resp.pv_erzeugung_kwh}"
+        )
+        # anlagenleistung_kwp = heute aktive Module = 6 kWp (B ist stillgelegt)
+        assert abs(resp.anlagenleistung_kwp - 6.0) < 0.01, (
+            f"anlagenleistung_kwp soll 6.0 (nur PV A heute aktiv) sein, "
+            f"war {resp.anlagenleistung_kwp}"
+        )
+        assert resp.spezifischer_ertrag_kwh_kwp is not None
+        assert abs(resp.spezifischer_ertrag_kwh_kwp - 1000.0) < 5.0, (
+            f"Teil-Rückbau: spez_ertrag muss 1000 kWh/kWp sein "
+            f"(per-Monat-aktives kWp), war {resp.spezifischer_ertrag_kwh_kwp}. "
+            f"Bug-Wert wäre ~1333 (heutige 6 kWp über alle 6 Jahre)."
+        )
+
+
 # ── Runner ──────────────────────────────────────────────────────────────────
 
 
@@ -206,6 +396,9 @@ _ASYNC_TESTS = [
     test_ytd_mit_pvgis_wird_annualisiert,
     test_komplettes_jahr_unveraendert,
     test_fallback_ohne_pvgis_nutzt_52n_verteilung,
+    test_alle_jahre_mit_anlagen_erweiterung,
+    test_alle_jahre_mit_teil_stilllegung,
+    test_alle_jahre_ignoriert_vor_pv_monate,
 ]
 
 


### PR DESCRIPTION
## Summary

Zwei Folgebugs zur periodengenauen Berechnung des spezifischen Ertrags (Vorgänger: 59dab9b1).

**Bug 1 — `covered_months` enthält zu viele Monate.** `set(zeitraum_monate) | monatsdaten_list` zog ALLE IMD-Typen (WP/Speicher/E-Auto) UND reine Stromzähler-Monate aus der Zeit vor PV-Inbetriebnahme in den Nenner. Bei `jahr=None` (alle Jahre) blähte sich `periode_anteil` dadurch um die Vor-PV-Historie auf — Symptom beim Anwender: spez_ertrag fiel auf ~300 kWh/kWp. **Fix:** `covered_months` jetzt nur aus PV-/BKW-IMDs (gefiltert über `ist_aktiv_im_monat`); Fallback auf Monatsdaten-Zeilen mit `pv_erzeugung_kwh > 0` für reine Zähler-Setups ohne IMDs.

**Bug 2 — Historische Größenänderungen ignoriert.** Der Nenner nutzte den heutigen kWp-Stand × Jahresanzahl. Erweiterungen (z. B. 3 kWp 2020 → 9 kWp ab 2023) wurden für die frühen Jahre überschätzt, Teilrückbau analog unterschätzt. **Fix:** neuer Helper `_kwp_aktiv_im_monat(jahr, monat)`, der pro Datenpunkt die damals aktiven PV-/BKW-Investitionen aufsummiert. Nenner wird zu `Σ (kwp_m × w_m)` statt `kwp_heute × Σ w_m`.

## Test plan

Suite wächst 3 → 6, alle grün:

- [x] `test_ytd_mit_pvgis_wird_annualisiert` — YTD Jan–Apr → ~1000 kWh/kWp
- [x] `test_komplettes_jahr_unveraendert` — Volljahr → exakt 1000 kWh/kWp
- [x] `test_fallback_ohne_pvgis_nutzt_52n_verteilung` — 52°N-Default greift
- [x] `test_alle_jahre_mit_anlagen_erweiterung` — 3→9 kWp historisch korrekt (Bug 2)
- [x] `test_alle_jahre_mit_teil_stilllegung` — Rückbau historisch korrekt (Bug 2)
- [x] `test_alle_jahre_ignoriert_vor_pv_monate` — WP-/Zähler-Drift gefixt (Bug 1)

Lauf: `eedc/backend/venv/bin/python eedc/backend/tests/test_cockpit_spez_ertrag_periode.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)