### PR TITLE
fix(daten-checker): NameError nach Merge-Konflikt #270↔v3.31.3

### DIFF
--- a/eedc/backend/services/daten_checker.py
+++ b/eedc/backend/services/daten_checker.py
@@ -1019,7 +1019,7 @@ class DatenChecker:
             # diesen Zweig meldete der Checker bei korrekt konfiguriertem
             # Premium-Setup (dietmar1968 Forum-PN 2026-05-17) eine fehlende
             # Abdeckung trotz vollständig gemappten getrennten Sensoren.
-            if inv.typ == "waermepumpe" and param.get("getrennte_strommessung", False):
+            if inv.typ == "waermepumpe" and (inv.parameter or {}).get("getrennte_strommessung", False):
                 erwartet = [["strom_heizen_kwh"], ["strom_warmwasser_kwh"]]
 
             inv_data = inv_map.get(str(inv.id), {}) or {}


### PR DESCRIPTION
## Problem

Nach Merge von #270 schlug `test_getrennte_strommessung_vollstaendig_ist_ok` mit `NameError: name 'param' is not defined` fehl.

## Ursache

#270 entfernte in `_check_energieprofil_abdeckung` die Helper-Variable `param = inv.parameter or {}` (ersetzt durch `ist_dienstlich(inv)`-Helper), aber der parallel in v3.31.3 (c20a126a, „WP mit getrennter Strommessung nicht als fehlend melden") eingefügte WP-Block referenzierte `param.get("getrennte_strommessung", False)` weiter.

Da beide Änderungen vor dem #270-Merge zeitlich verschränkt entstanden, ließ die Konflikt-Auflösung die `param`-Referenz im neu hinzugefügten Block stehen.

## Fix

Inline statt Helper-Variable in der einen verbleibenden Lesestelle:

```diff
-if inv.typ == "waermepumpe" and param.get("getrennte_strommessung", False):
+if inv.typ == "waermepumpe" and (inv.parameter or {}).get("getrennte_strommessung", False):
```

## Verifikation

`pytest eedc/backend/tests/` von 166/167 grün auf 167/167 grün.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>