### PR TITLE
security: Hardening — Credential-Maskierung + SSRF-Block + Setup-Docs (Tom-Review)

### DIFF
--- a/docs/SETUP_DEVMACHINE.md
+++ b/docs/SETUP_DEVMACHINE.md
@@ -6,9 +6,17 @@ Anleitung zum Aufsetzen einer identischen Entwicklungsumgebung auf einem neuen U
 
 ## Schnellstart: Setup-Script ausführen
 
+> **Sicherheitshinweis:** Lade das Script herunter, **sichte den Inhalt**, und führe es dann aus. Pipe-to-shell (`curl | bash`) wird hier bewusst nicht empfohlen — ein kompromittiertes Repo würde den fremden Code sonst ohne Prüfung mit deinem Login-User laufen lassen.
+
 ```bash
-# Script herunterladen und ausführen
-curl -fsSL https://raw.githubusercontent.com/supernova1963/eedc-homeassistant/main/docs/setup-devmachine.sh | bash
+# 1. Script herunterladen
+curl -fsSL -o /tmp/eedc-setup.sh https://raw.githubusercontent.com/supernova1963/eedc-homeassistant/main/docs/setup-devmachine.sh
+
+# 2. Inhalt sichten (insbesondere die `sudo`- und `npm install -g`-Stellen)
+less /tmp/eedc-setup.sh
+
+# 3. Nach Prüfung ausführen
+bash /tmp/eedc-setup.sh
 ```
 
 Oder manuell Schritt für Schritt nach dieser Anleitung.
@@ -32,8 +40,11 @@ sudo apt update && sudo apt install -y \
 ## 2. Node.js via NVM
 
 ```bash
-# NVM installieren
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+# NVM-Installer herunterladen, sichten, dann ausführen
+# (Aktuelle Version: https://github.com/nvm-sh/nvm/releases — Tag-Pfad ggf. anpassen)
+curl -fsSL -o /tmp/nvm-install.sh https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh
+less /tmp/nvm-install.sh
+bash /tmp/nvm-install.sh
 
 # Shell neu laden
 source ~/.bashrc   # oder: source ~/.zshrc

--- a/docs/setup-devmachine.sh
+++ b/docs/setup-devmachine.sh
@@ -19,7 +19,13 @@ info "System-Pakete installiert"
 
 section "2. NVM + Node.js 20"
 if [ ! -d "$HOME/.nvm" ]; then
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+  # Installer erst lokal ziehen statt direkt zu pipen, dann ausführen.
+  # Defense-in-Depth: wenn diese Datei selbst kompromittiert wäre, sieht der
+  # Caller wenigstens die NVM-Installer-Datei in /tmp vor dem zweiten Schritt.
+  NVM_INSTALLER=$(mktemp /tmp/nvm-install.XXXXXX.sh)
+  curl -fsSL -o "$NVM_INSTALLER" https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh
+  bash "$NVM_INSTALLER"
+  rm -f "$NVM_INSTALLER"
   info "NVM installiert"
 else
   info "NVM bereits vorhanden"

--- a/eedc/backend/api/routes/cloud_import.py
+++ b/eedc/backend/api/routes/cloud_import.py
@@ -35,6 +35,53 @@ def _trim_credentials(credentials: dict) -> dict:
     }
 
 
+# Heuristik-Fallback für die Maskierung in GET /credentials/{anlage_id}.
+# Greift, wenn der Provider nicht aufgelöst werden kann (entfernt/umbenannt)
+# oder ein Provider neue sensible Feld-IDs einführt, ohne `type="password"`
+# zu setzen. Pattern werden als Substring im Key-Lower gesucht.
+_SENSITIVE_KEY_PATTERNS: tuple[str, ...] = (
+    "secret", "password", "token", "api_key", "access_key",
+    "private_key", "app_secret", "client_secret", "system_code",
+)
+
+
+def _maskiere_credentials(creds: dict, provider_id: Optional[str]) -> dict:
+    """Maskiert sensible Credential-Werte für die Anzeige.
+
+    Strategie (deny-by-default für unbekannte Felder):
+      1. Felder mit Provider-Definition `type="password"` werden maskiert.
+      2. Zusätzlich Heuristik: Key enthält ein bekanntes sensibles Substring
+         (`secret`, `password`, `token`, `api_key`, `access_key`, ...). Greift
+         auch, wenn der Provider nicht auflösbar ist (entfernt/umbenannt).
+      3. Identifier (`username`, `email`, `site_id`, `region`, ...) bleiben
+         lesbar, damit das Frontend die gespeicherte Konfiguration zeigen kann.
+
+    Leere/None-Werte werden ausgelassen.
+    """
+    password_field_ids: set[str] = set()
+    if provider_id:
+        try:
+            provider = get_provider(provider_id)
+            password_field_ids = {
+                f.id for f in provider.info().credential_fields if f.type == "password"
+            }
+        except Exception:
+            # Unbekannter/entfernter Provider oder Info-Fehler darf nicht zur
+            # Klartext-Antwort führen — Heuristik unten übernimmt dann allein.
+            password_field_ids = set()
+
+    masked: dict = {}
+    for key, val in (creds or {}).items():
+        if val is None or val == "":
+            continue
+        is_sensitive = (
+            key in password_field_ids
+            or any(pat in key.lower() for pat in _SENSITIVE_KEY_PATTERNS)
+        )
+        masked[key] = "***" if is_sensitive else val
+    return masked
+
+
 # ─── Schemas ─────────────────────────────────────────────────────────────────
 
 
@@ -216,14 +263,14 @@ async def get_credentials(
     if not cloud_config:
         return CredentialsResponse(has_credentials=False)
 
-    # Secrets maskieren
-    creds = dict(cloud_config.get("credentials", {}))
-    for key in ("secret_key", "password", "token"):
-        if key in creds and creds[key]:
-            creds[key] = "***"
+    # Secrets maskieren — Provider-aware (type="password") + Heuristik-Fallback,
+    # damit `api_key`, `app_secret`, `access_key_value` etc. nicht mehr im Klartext
+    # zurückgegeben werden. Identifier (username/email/site_id/...) bleiben sichtbar.
+    provider_id = cloud_config.get("provider_id")
+    creds = _maskiere_credentials(cloud_config.get("credentials", {}), provider_id)
 
     return CredentialsResponse(
-        provider_id=cloud_config.get("provider_id"),
+        provider_id=provider_id,
         credentials=creds,
         has_credentials=True,
     )

--- a/eedc/backend/api/routes/connector.py
+++ b/eedc/backend/api/routes/connector.py
@@ -6,9 +6,12 @@ Endpoints für die direkte Verbindung zu Wechselrichtern/Energiemanagement-Syste
 """
 
 import base64
+import ipaddress
 import logging
+import socket
 from datetime import datetime, timezone
 from typing import Optional
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -62,6 +65,80 @@ def _decode_password(encoded: str) -> str:
     return base64.b64decode(encoded.encode()).decode()
 
 
+def _extract_hostname(host: str) -> Optional[str]:
+    """Extrahiert den reinen Hostnamen aus einer URL oder einem Bare-Host-String.
+
+    `https://192.168.1.50:80/api` → `192.168.1.50`
+    `192.168.1.50:80` → `192.168.1.50`
+    `wechselrichter.lan` → `wechselrichter.lan`
+    """
+    if not host:
+        return None
+    parsed = urlparse(host if "://" in host else f"//{host}", scheme="")
+    return parsed.hostname
+
+
+def _validate_connector_host(host: str) -> None:
+    """Defense-in-Depth: blockt SSRF-Ziele bevor der Connector requestet.
+
+    Erlaubt: Public-IPs, private LAN-Bereiche (10/8, 172.16/12, 192.168/16) und
+    DNS-Namen, die auf solche Adressen auflösen. Geblockt:
+
+      - Loopback (`127.0.0.0/8`, `::1`)
+      - Link-local (`169.254.0.0/16`, `fe80::/10`) — schließt Cloud-Metadata-Endpoints ein
+      - Multicast (`224.0.0.0/4`, `ff00::/8`)
+      - Unspecified (`0.0.0.0`, `::`)
+      - Reserviert (`240.0.0.0/4`)
+
+    DNS-Rebinding: alle aus `getaddrinfo` zurückgegebenen Adressen werden geprüft
+    — wenn ein Hostname auf eine geblockte Adresse auflöst, schlägt die
+    Validierung fehl.
+
+    Raises HTTPException(400) bei Verstoß.
+    """
+    hostname = _extract_hostname(host)
+    if not hostname:
+        raise HTTPException(status_code=400, detail="Host fehlt oder ungültig.")
+
+    try:
+        addrinfo = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Host nicht auflösbar: {hostname} ({exc})",
+        )
+
+    seen_addresses: set[str] = set()
+    for family, _socktype, _proto, _canonname, sockaddr in addrinfo:
+        ip_str = sockaddr[0]
+        if ip_str in seen_addresses:
+            continue
+        seen_addresses.add(ip_str)
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if (
+            ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_unspecified
+            or ip.is_reserved
+        ):
+            logger.warning(
+                "Connector-Host blockiert (SSRF-Schutz): hostname=%s, resolved=%s",
+                hostname, ip_str,
+            )
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Ziel-Host nicht erlaubt: {hostname} → {ip_str} "
+                    f"(Loopback/Link-local/Metadata-Endpunkte sind aus "
+                    f"Sicherheitsgründen ausgeschlossen)."
+                ),
+            )
+
+
 async def _get_anlage(anlage_id: int, db: AsyncSession) -> Anlage:
     """Lädt eine Anlage oder wirft 404."""
     result = await db.execute(select(Anlage).where(Anlage.id == anlage_id))
@@ -93,6 +170,7 @@ async def test_connection(req: ConnectorTestRequest):
     except ValueError:
         raise HTTPException(status_code=400, detail=f"Unbekannter Connector: {req.connector_id}")
 
+    _validate_connector_host(req.host)
     result = await connector.test_connection(req.host, req.username, req.password)
     await log_activity(
         kategorie="connector_test",
@@ -119,6 +197,8 @@ async def setup_connector(
         connector = get_connector(req.connector_id)
     except ValueError:
         raise HTTPException(status_code=400, detail=f"Unbekannter Connector: {req.connector_id}")
+
+    _validate_connector_host(req.host)
 
     # Verbindung testen + initialen Snapshot holen
     test_result = await connector.test_connection(req.host, req.username, req.password)

--- a/eedc/backend/tests/test_cloud_credentials_maskierung.py
+++ b/eedc/backend/tests/test_cloud_credentials_maskierung.py
@@ -1,0 +1,181 @@
+"""
+Akzeptanztest: Cloud-Credentials-Maskierung in GET /credentials/{anlage_id}.
+
+Vor dem Fix maskierte der Endpoint nur drei Felder hartcodiert
+(`secret_key`, `password`, `token`). Provider-spezifische Geheimnisse wie
+`api_key` (SolarEdge), `app_secret` (Deye Solarman), `access_key_value`
+(Fronius Solar.web) oder `system_code` (Huawei FusionSolar) blieben Klartext.
+
+Der Fix nutzt zwei Mechanismen:
+  1. Provider-aware: Felder mit `CredentialField(type="password")` werden
+     maskiert (Quelle der Wahrheit pro Provider).
+  2. Heuristik-Fallback für unbekannte/entfernte Provider: Substring-Match
+     im Key auf `secret`, `password`, `token`, `api_key`, `access_key`,
+     `private_key`, `app_secret`, `client_secret`, `system_code`.
+
+Identifier (`username`, `email`, `site_id`, `region`, ...) bleiben lesbar.
+
+Self-contained:
+
+    eedc/backend/venv/bin/python eedc/backend/tests/test_cloud_credentials_maskierung.py
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from pathlib import Path
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]  # eedc/
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+from backend.api.routes.cloud_import import _maskiere_credentials  # noqa: E402
+
+
+# ----------------------------------------------------------------------------
+# Provider-aware Maskierung (type="password")
+# ----------------------------------------------------------------------------
+
+def test_solaredge_api_key_wird_maskiert() -> None:
+    """Tom-HA-Hinweis: SolarEdge api_key war vorher Klartext, jetzt maskiert."""
+    creds = {"api_key": "abc123secret", "site_id": "1234567"}
+    result = _maskiere_credentials(creds, provider_id="solaredge")
+    assert result["api_key"] == "***", f"api_key sollte maskiert sein, got {result}"
+    assert result["site_id"] == "1234567", "site_id ist kein Geheimnis, bleibt Klartext"
+
+
+def test_deye_app_secret_wird_maskiert() -> None:
+    """Deye Solarman: app_secret (type=password) + app_id (type=text)."""
+    creds = {"app_id": "12345", "app_secret": "top-secret-app", "email": "user@example.com", "password": "abc"}
+    result = _maskiere_credentials(creds, provider_id="deye_solarman")
+    assert result["app_secret"] == "***"
+    assert result["password"] == "***"
+    assert result["app_id"] == "12345"
+    assert result["email"] == "user@example.com"
+
+
+def test_fronius_access_key_value_wird_maskiert() -> None:
+    """Fronius Solar.web: access_key_value ist Password-Feld, access_key_id ist Identifier."""
+    creds = {"access_key_id": "ID-PUBLIC-ABC", "access_key_value": "geheim", "pv_system_id": "sys-1"}
+    result = _maskiere_credentials(creds, provider_id="fronius_solarweb")
+    assert result["access_key_value"] == "***"
+    assert result["access_key_id"] == "***", "access_key Substring-Heuristik schlägt auch hier zu (defense)"
+    assert result["pv_system_id"] == "sys-1"
+
+
+def test_huawei_system_code_wird_maskiert() -> None:
+    """Huawei FusionSolar: system_code ist Password-Typ."""
+    creds = {"username": "user@example.com", "system_code": "PWD123", "station_code": "STA456"}
+    result = _maskiere_credentials(creds, provider_id="huawei_fusionsolar")
+    assert result["system_code"] == "***"
+    assert result["username"] == "user@example.com"
+    assert result["station_code"] == "STA456"
+
+
+# ----------------------------------------------------------------------------
+# Heuristik-Fallback (unbekannter Provider)
+# ----------------------------------------------------------------------------
+
+def test_unbekannter_provider_maskiert_sensible_keys_per_heuristik() -> None:
+    """Wenn Provider nicht aufgelöst werden kann, Substring-Heuristik schützt."""
+    creds = {
+        "api_key": "abc",
+        "client_secret": "geheim",
+        "private_key": "-----BEGIN RSA",
+        "bearer_token": "eyJ...",
+        "username": "u",
+        "endpoint": "https://api.example.com",
+    }
+    result = _maskiere_credentials(creds, provider_id="nonexistent-provider-id")
+    assert result["api_key"] == "***"
+    assert result["client_secret"] == "***"
+    assert result["private_key"] == "***"
+    assert result["bearer_token"] == "***", "Substring 'token' matched"
+    assert result["username"] == "u"
+    assert result["endpoint"] == "https://api.example.com"
+
+
+def test_kein_provider_id_immer_noch_heuristik() -> None:
+    """provider_id=None: Heuristik schützt weiterhin."""
+    creds = {"password": "secret123", "username": "u"}
+    result = _maskiere_credentials(creds, provider_id=None)
+    assert result["password"] == "***"
+    assert result["username"] == "u"
+
+
+# ----------------------------------------------------------------------------
+# Identifier bleiben lesbar
+# ----------------------------------------------------------------------------
+
+def test_identifier_bleiben_klartext() -> None:
+    """username/email/site_id/region/server/endpoint sind keine Geheimnisse."""
+    creds = {
+        "username": "alice",
+        "email": "alice@example.com",
+        "site_id": "12345",
+        "station_id": "98765",
+        "plant_id": "55",
+        "region": "eu1",
+        "server": "https://api.example.com",
+        "account": "acc-1",
+    }
+    result = _maskiere_credentials(creds, provider_id="growatt")
+    for key in ("username", "email", "site_id", "station_id", "plant_id", "region", "server", "account"):
+        if key in result:
+            assert result[key] != "***", f"{key} sollte Klartext sein, ist maskiert"
+
+
+# ----------------------------------------------------------------------------
+# Empty/None werden weggelassen
+# ----------------------------------------------------------------------------
+
+def test_leere_werte_werden_weggelassen() -> None:
+    """None und leere Strings tauchen nicht im Output auf — sauberer fürs Frontend."""
+    creds = {"api_key": "abc", "site_id": None, "username": ""}
+    result = _maskiere_credentials(creds, provider_id="solaredge")
+    assert "site_id" not in result
+    assert "username" not in result
+    assert result["api_key"] == "***"
+
+
+def test_leere_credentials_dict_liefert_leeres_dict() -> None:
+    result = _maskiere_credentials({}, provider_id="solaredge")
+    assert result == {}
+
+
+# ----------------------------------------------------------------------------
+# Runner
+# ----------------------------------------------------------------------------
+
+ALLE_TESTS = [
+    test_solaredge_api_key_wird_maskiert,
+    test_deye_app_secret_wird_maskiert,
+    test_fronius_access_key_value_wird_maskiert,
+    test_huawei_system_code_wird_maskiert,
+    test_unbekannter_provider_maskiert_sensible_keys_per_heuristik,
+    test_kein_provider_id_immer_noch_heuristik,
+    test_identifier_bleiben_klartext,
+    test_leere_werte_werden_weggelassen,
+    test_leere_credentials_dict_liefert_leeres_dict,
+]
+
+
+def main() -> int:
+    fehler = 0
+    for fn in ALLE_TESTS:
+        try:
+            fn()
+            print(f"PASS  {fn.__name__}")
+        except Exception:  # noqa: BLE001
+            fehler += 1
+            print(f"FAIL  {fn.__name__}")
+            traceback.print_exc()
+    if fehler:
+        print(f"\n{fehler} Tests fehlgeschlagen.")
+        return 1
+    print(f"\nAlle {len(ALLE_TESTS)} Tests grün.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eedc/backend/tests/test_connector_ssrf_block.py
+++ b/eedc/backend/tests/test_connector_ssrf_block.py
@@ -1,0 +1,220 @@
+"""
+Akzeptanztest: SSRF-Loopback-Block für `/api/connector/test` + `/api/connector/setup`.
+
+Defense-in-Depth gegen Server-Side-Request-Forgery. Der Connector-Test-Endpoint
+nahm vorher beliebige Hosts entgegen und schickte Requests dagegen — ein
+authentifizierter Aufrufer konnte den Server gegen interne Endpoints,
+Cloud-Metadata-Services oder den HA-Supervisor pivotieren.
+
+Geblockt: Loopback, Link-local, Multicast, Unspecified, Reserved.
+Erlaubt: Public-IPs + LAN-Bereiche (10/8, 172.16/12, 192.168/16) + DNS-Namen,
+die auf solche Adressen auflösen.
+
+Self-contained:
+
+    eedc/backend/venv/bin/python eedc/backend/tests/test_connector_ssrf_block.py
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from pathlib import Path
+from unittest.mock import patch
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]  # eedc/
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+from fastapi import HTTPException  # noqa: E402
+
+from backend.api.routes.connector import (  # noqa: E402
+    _extract_hostname,
+    _validate_connector_host,
+)
+
+
+# ----------------------------------------------------------------------------
+# Hostname-Extraktion
+# ----------------------------------------------------------------------------
+
+def test_extract_hostname_bare_ip() -> None:
+    assert _extract_hostname("192.168.1.50") == "192.168.1.50"
+
+
+def test_extract_hostname_url() -> None:
+    assert _extract_hostname("https://192.168.1.50:80/api") == "192.168.1.50"
+
+
+def test_extract_hostname_port_only() -> None:
+    assert _extract_hostname("192.168.1.50:8080") == "192.168.1.50"
+
+
+def test_extract_hostname_dns_name() -> None:
+    assert _extract_hostname("wechselrichter.lan") == "wechselrichter.lan"
+
+
+# ----------------------------------------------------------------------------
+# Gefährliche Hosts werden geblockt
+# ----------------------------------------------------------------------------
+
+def _assert_blocked(host: str, resolved_ips: list[str]) -> None:
+    """Hilfsfunktion: mockt getaddrinfo, erwartet HTTPException."""
+    addrinfo = [(2, 1, 6, "", (ip, 0)) for ip in resolved_ips]
+    with patch("backend.api.routes.connector.socket.getaddrinfo", return_value=addrinfo):
+        try:
+            _validate_connector_host(host)
+        except HTTPException as e:
+            assert e.status_code == 400
+            return
+        raise AssertionError(f"Host {host} ({resolved_ips}) sollte blockiert sein")
+
+
+def _assert_allowed(host: str, resolved_ips: list[str]) -> None:
+    addrinfo = [(2, 1, 6, "", (ip, 0)) for ip in resolved_ips]
+    with patch("backend.api.routes.connector.socket.getaddrinfo", return_value=addrinfo):
+        _validate_connector_host(host)  # darf nicht werfen
+
+
+def test_loopback_127_geblockt() -> None:
+    _assert_blocked("127.0.0.1", ["127.0.0.1"])
+
+
+def test_loopback_alle_127_subnet_geblockt() -> None:
+    _assert_blocked("127.5.5.5", ["127.5.5.5"])
+
+
+def test_aws_metadata_geblockt() -> None:
+    """169.254.169.254 ist AWS/GCP/Azure-Cloud-Metadata-Endpoint."""
+    _assert_blocked("169.254.169.254", ["169.254.169.254"])
+
+
+def test_link_local_169_254_geblockt() -> None:
+    _assert_blocked("169.254.1.50", ["169.254.1.50"])
+
+
+def test_ipv6_loopback_geblockt() -> None:
+    _assert_blocked("::1", ["::1"])
+
+
+def test_multicast_geblockt() -> None:
+    _assert_blocked("224.0.0.1", ["224.0.0.1"])
+
+
+def test_unspecified_geblockt() -> None:
+    _assert_blocked("0.0.0.0", ["0.0.0.0"])
+
+
+def test_dns_rebinding_geblockt() -> None:
+    """Hostname löst auf Loopback auf → geblockt (auch wenn Hostname harmlos klingt)."""
+    _assert_blocked("wechselrichter.evil.com", ["127.0.0.1"])
+
+
+def test_dns_rebinding_alle_aufloesungen_geprueft() -> None:
+    """Wenn auch nur EINE der aufgelösten IPs geblockt ist → reject."""
+    _assert_blocked("multi.example.com", ["192.168.1.50", "127.0.0.1"])
+
+
+# ----------------------------------------------------------------------------
+# Erlaubte Hosts
+# ----------------------------------------------------------------------------
+
+def test_private_lan_10er_erlaubt() -> None:
+    _assert_allowed("10.0.0.5", ["10.0.0.5"])
+
+
+def test_private_lan_192_168_erlaubt() -> None:
+    _assert_allowed("192.168.1.50", ["192.168.1.50"])
+
+
+def test_private_lan_172_16_erlaubt() -> None:
+    _assert_allowed("172.16.0.1", ["172.16.0.1"])
+
+
+def test_public_ip_erlaubt() -> None:
+    """Public-IPs sind erlaubt (für Cloud-Connectors mit explizitem Endpoint)."""
+    _assert_allowed("8.8.8.8", ["8.8.8.8"])
+
+
+def test_dns_name_auf_lan_erlaubt() -> None:
+    _assert_allowed("wechselrichter.lan", ["192.168.1.50"])
+
+
+def test_url_form_erlaubt() -> None:
+    _assert_allowed("https://192.168.1.50:80/api", ["192.168.1.50"])
+
+
+# ----------------------------------------------------------------------------
+# Edge cases
+# ----------------------------------------------------------------------------
+
+def test_leerer_host_wirft() -> None:
+    try:
+        _validate_connector_host("")
+    except HTTPException as e:
+        assert e.status_code == 400
+        return
+    raise AssertionError("Leerer Host sollte HTTPException werfen")
+
+
+def test_unresolvable_host_wirft() -> None:
+    import socket as _socket
+    with patch(
+        "backend.api.routes.connector.socket.getaddrinfo",
+        side_effect=_socket.gaierror("Name or service not known"),
+    ):
+        try:
+            _validate_connector_host("does-not-resolve.invalid")
+        except HTTPException as e:
+            assert e.status_code == 400
+            return
+        raise AssertionError("Unresolvable Host sollte HTTPException werfen")
+
+
+# ----------------------------------------------------------------------------
+# Runner
+# ----------------------------------------------------------------------------
+
+ALLE_TESTS = [
+    test_extract_hostname_bare_ip,
+    test_extract_hostname_url,
+    test_extract_hostname_port_only,
+    test_extract_hostname_dns_name,
+    test_loopback_127_geblockt,
+    test_loopback_alle_127_subnet_geblockt,
+    test_aws_metadata_geblockt,
+    test_link_local_169_254_geblockt,
+    test_ipv6_loopback_geblockt,
+    test_multicast_geblockt,
+    test_unspecified_geblockt,
+    test_dns_rebinding_geblockt,
+    test_dns_rebinding_alle_aufloesungen_geprueft,
+    test_private_lan_10er_erlaubt,
+    test_private_lan_192_168_erlaubt,
+    test_private_lan_172_16_erlaubt,
+    test_public_ip_erlaubt,
+    test_dns_name_auf_lan_erlaubt,
+    test_url_form_erlaubt,
+    test_leerer_host_wirft,
+    test_unresolvable_host_wirft,
+]
+
+
+def main() -> int:
+    fehler = 0
+    for fn in ALLE_TESTS:
+        try:
+            fn()
+            print(f"PASS  {fn.__name__}")
+        except Exception:  # noqa: BLE001
+            fehler += 1
+            print(f"FAIL  {fn.__name__}")
+            traceback.print_exc()
+    if fehler:
+        print(f"\n{fehler} Tests fehlgeschlagen.")
+        return 1
+    print(f"\nAlle {len(ALLE_TESTS)} Tests grün.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Hintergrund

Externer Security-Review (Tom-HA, 2026-05-18) hat 13 Punkte aufgelistet. Nach Triage (Existenz × Exposure × User-Mehrwert) verbleiben drei mit echtem Defense-in-Depth-Wert. Kein Endanwender-Schaden-Pfad bekannt — alle drei Endpoints sind hinter HA-Ingress-Auth. Trotzdem sauber zu fixen.

Andere Tom-Punkte sind entweder kontextuell nicht anwendbar (Auth-Guard ist HA-Ingress, CORS ist Same-Origin durch Proxy, Swagger ist deaktiviert), oder die Information ist bereits öffentlich (Username/Name aus Forum, `/home/gernot/`-Pfade in Docs).

## Drei Fixes

### 1. P0.5 Credential-Maskierung deny-by-default — Commit 84f6ad01

Vorher: `GET /api/cloud-import/credentials/{anlage_id}` maskierte nur 3 hartcodierte Felder (`secret_key`, `password`, `token`). Provider-spezifische Geheimnisse blieben Klartext: SolarEdge-`api_key`, Deye-`app_secret`, Fronius-`access_key_value`, Huawei-`system_code`.

Fix: Neuer Helper `_maskiere_credentials(creds, provider_id)` mit zwei Mechanismen:
- **Provider-aware:** Felder mit `CredentialField(type=\"password\")` werden maskiert (Quelle der Wahrheit pro Provider)
- **Heuristik-Fallback:** Substring-Match auf `secret`, `password`, `token`, `api_key`, `access_key`, `private_key`, `app_secret`, `client_secret`, `system_code` — greift bei unbekannten/entfernten Providern und neuen Feld-IDs ohne `type=\"password\"`

Identifier (`username`, `email`, `site_id`, `region`, ...) bleiben Klartext — Frontend zeigt weiterhin die Konfiguration an.

9 neue Akzeptanztests in `test_cloud_credentials_maskierung.py`.

### 2. P0.3 SSRF-Loopback-Block — Commit 5367d16c

Vorher: `/api/connector/test` und `/api/connector/setup` nahmen beliebige Hosts entgegen und schickten Requests dagegen. Authentifizierter Nutzer konnte den Server gegen interne Endpoints pivotieren (HA-Supervisor `127.0.0.1`, Add-on-zu-Add-on `172.30.32.x`, Cloud-Metadata `169.254.169.254`).

Fix: Neue Helper in `connector.py`:
- `_extract_hostname(host)` — Bare-IP / URL / Port-Form parsen
- `_validate_connector_host(host)` — via `getaddrinfo` auflösen, jede zurückgegebene IP gegen `ipaddress.is_loopback / is_link_local / is_multicast / is_unspecified / is_reserved` prüfen. Erlaubt: Public-IPs + private LAN-Bereiche (10/8, 172.16/12, 192.168/16). DNS-Rebinding-Schutz: wenn auch nur eine aufgelöste IP geblockt ist, schlägt die Validierung fehl.

21 Akzeptanztests in `test_connector_ssrf_block.py` (Loopback, Link-local, AWS-Metadata, IPv6, Multicast, DNS-Rebinding, LAN-Bereiche erlaubt, URL-Form).

### 3. P2.1 `curl | bash` durch download-sichten-ausführen — Commit 6842a3e8

Vorher: Setup-Anleitung empfahl Pipe-to-shell mit dem Login-User. Trust-Hygiene-Problem für Beitragende (kein Endanwender-Pfad).

Fix:
- `docs/SETUP_DEVMACHINE.md` + Website-Pendant: explizite `curl -o /tmp/x.sh` → `less` → `bash /tmp/x.sh` Sequenz mit Sicherheitshinweis vorab
- `docs/setup-devmachine.sh`: NVM-Bootstrap im Script selbst auf gleiche Sequenz umgestellt (`mktemp` + `curl -o` + `bash`)

## Verifikation

`pytest eedc/backend/tests/` — **215/215 grün** (vorher 185, +30 neue Tests: 9 Maskierung + 21 SSRF).

## Kontext

Keine Bedrohung für eedc-Endanwender. Alle drei API-Endpoints sind hinter HA-Ingress-Auth → erfordert HA-Login. Risiko-Szenarien: Mitbewohner mit HA-Zugriff, Browser-DevTools-Screenshots in Bug-Reports, HA-Add-on-Pivot. Defense-in-Depth-Standard.

Memory-Linien: `feedback_silent_except_logs` (klare 400-Begründung statt silent reject), `feedback_aggregations_drift` (SoT-Helper-Pattern für Maskierung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)