### PR TITLE
docs(readme): Standalone-Modus als LAN-Only kennzeichnen

### DIFF
--- a/eedc/README.md
+++ b/eedc/README.md
@@ -30,6 +30,24 @@ docker-compose up -d
 
 EEDC ist erreichbar unter: http://localhost:8099
 
+## ⚠️ Sicherheit: Standalone-Modus ist für LAN-Betrieb gedacht
+
+Die Standalone-Distribution (dieser Container, `docker-compose up`) bietet **keine eigene Authentifizierung** auf der HTTP-API. Anders als die Home-Assistant-Add-on-Variante (die hinter dem HA-Ingress-Auth-Proxy läuft) wird der Port `8099` direkt vom Container an das Host-LAN exponiert.
+
+**Daraus folgt:**
+
+- ✅ Betrieb im **eigenen, vertrauenswürdigen LAN** (Heimnetz hinter Router-Firewall) ist der gedachte Anwendungsfall.
+- ❌ **Niemals direkt ins Internet exponieren** — kein Port-Forwarding auf 8099, keine Cloudflare-Tunnel ohne Auth-Layer davor, kein Reverse-Proxy ohne Basic-Auth oder mTLS.
+- ⚠️ **In geteilten Netzen vorsichtig** (Gäste-WLAN, WG, Co-Working): wer im selben Subnetz ist, erreicht die API. Cloud-Credentials und Anlagendaten sind damit ohne Auth lesbar.
+
+**Wer Internet-Zugriff braucht:**
+
+- VPN ins Heimnetz (WireGuard, Tailscale) ist der einfachste und sicherste Weg.
+- Reverse-Proxy mit Basic-Auth / OAuth2-Proxy / Cloudflare Access davor, wenn HTTPS-Zugang von außen wirklich nötig ist.
+- Oder: die Home-Assistant-Add-on-Variante installieren — HA-Login schützt die API dann automatisch.
+
+Ein eigener API-Auth-Layer für den Standalone-Container ist in der Roadmap [#110](https://github.com/supernova1963/eedc-homeassistant/issues/110), aber bis dahin gilt: **LAN-Only, niemals ungeschützt ins Internet**.
+
 ### Entwicklung
 
 ```bash


### PR DESCRIPTION
## Hintergrund

Tom-HA-Code-Review (2026-05-18) hat 13 Punkte gegen das Repo aufgelistet. Bei der Triage (Existenz × Exposure × User-Mehrwert) fiel auf: die meisten P0-Punkte sind im **HA-Add-on-Modus** kontextuell relativierbar (HA-Ingress-Auth davor), im **Standalone-Modus** (docker-compose) aber real, weil dort kein Auth-Layer existiert und Port 8099 direkt ans Host-LAN exponiert wird.

Bisheriges README sagte nichts über das Trust-Modell — implizite Annahme „LAN-Betrieb", aber nirgends ausgesprochen.

## Was dieser PR macht

Neuer Sicherheits-Block in `eedc/README.md` direkt nach dem Schnellstart, der das Trust-Modell explizit macht:

- ✅ LAN-Betrieb hinter Router-Firewall = gedachter Anwendungsfall
- ❌ Niemals direkt ins Internet exponieren (kein Port-Forwarding auf 8099, keine Cloudflare-Tunnel ohne Auth davor)
- ⚠️ Geteilte Netze vorsichtig (Gäste-WLAN, WG, Co-Working)
- Empfehlungen für Internet-Zugriff: VPN (WireGuard, Tailscale) oder Reverse-Proxy mit Auth (Basic-Auth, OAuth2-Proxy, Cloudflare Access, Tailscale Funnel) — oder einfach HA-Add-on-Variante

## Was bewusst nicht passiert

**Kein eigener Auth-Layer im Container geplant.** Anwender, die Docker betreiben, kennen Reverse-Proxy-Setups; eine eigene Auth-Implementierung würde Standard-Infrastruktur nachbauen, ohne ihre Edge-Cases (Rate-Limiting, MFA, OIDC-Integration) abzudecken. Klare Konvention statt Re-Implementierung — wer kein Reverse-Proxy-Setup will, ist im HA-Add-on-Modus besser aufgehoben.

## Test plan

- [x] README-Block visuell prüfen (Markdown rendert sauber, GitHub-Vorschau)
- [x] Keine Code-Änderung, keine Test-Suite-Auswirkung

🤖 Generated with [Claude Code](https://claude.com/claude-code)