### PR TITLE
fix(gitignore): eedc/data/*.bak ergänzen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ htmlcov/
 # zusätzliche Backup-Targets oder Test-Snapshots automatisch mit greifen.
 eedc/data/*-wal
 eedc/data/*-shm
+# Backup-DBs (.bak) selbst. Nach dem History-Rewrite zur Entfernung der
+# historischen `eedc.db.bak` muss das Pattern verhindern, dass die Datei
+# bei einem späteren `git add .` wieder in den Index rutscht. Die .bak-
+# Endung greift NICHT durch das allgemeine `*.db`-Pattern oben.
+eedc/data/*.bak


### PR DESCRIPTION
Kleiner Folge-Fix zum History-Rewrite, der `eedc/data/eedc.db.bak` aus der Historie entfernt hat.

## Was und warum

Die allgemeinen Patterns `*.db`, `*.sqlite`, `*.sqlite3` im `.gitignore` greifen **nicht** für die `.bak`-Endung — `eedc/data/eedc.db.bak` matched ohne expliziten Eintrag keinen Filter. Ohne dieses Pattern würde die Datei bei einem späteren `git add .` (oder beim Wiederherstellen des HA-Add-on-Backups) erneut in den Index rutschen und der History-Rewrite wäre umsonst gewesen.

## Wahl des Patterns

Analog zu #272 (WAL/SHM-Files) bewusst breit (`eedc/data/*.bak` statt fest auf `eedc.db.bak`) — damit zusätzliche Backup-Targets oder Test-Snapshots in `eedc/data/` automatisch mit greifen.

## Verifikation

```
git check-ignore -v eedc/data/eedc.db.bak
.gitignore:71:eedc/data/*.bak	eedc/data/eedc.db.bak
```

## Test plan

- [ ] `git check-ignore -v eedc/data/eedc.db.bak` matched das neue Pattern
- [ ] `git status` zeigt eine vorhandene `.bak`-Datei in `eedc/data/` nicht mehr als untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)